### PR TITLE
Added protogen workflow example

### DIFF
--- a/docs/running_workflows.rst
+++ b/docs/running_workflows.rst
@@ -141,6 +141,20 @@ A workflow is just a set of tasks with inputs and outputs linked appropriately. 
 
 Note that a workflow is instantiated with a list of tasks.  The tasks will get executed when their inputs are satisfied and ready to go.
 
+Running Workflow With Multiple Tasks
+-----------------------
+
+A workflow with multiple tasks will behave like a workflow with a single task. See example python script "run_protogen_lulc_gbdxtools.py" for more detail on how to chain tasks together.  The code sample below shows how these tasks are declared and connected before they create the final workflow json.
+
+.. code-block:: python
+
+    aoptask = gbdx.Task("AOP_Strip_Processor", data=data, enable_acomp=True, enable_pansharpen=False,enable_dra=False,bands='MS')
+    pp_task = gbdx.Task("ProtogenPrep",raster=aoptask.outputs.data.value)      # ProtogenPrep task is used to get AOP output into proper format for protogen task
+    prot_lulc = gbdx.Task("protogenV2LULC",raster=pp_task.outputs.data.value)
+    # build the workflow ( AOP -> ProtogenPrep -> protogenV2LULC )
+    workflow = gbdx.Workflow([ aoptask,pp_task,prot_lulc ]) 
+    workflow.savedata(prot_lulc.outputs.data.value, location=out_data_loc)
+
 
 Workflow Status
 -----------------------

--- a/examples/run_protogen_lulc_gbdxtools.py
+++ b/examples/run_protogen_lulc_gbdxtools.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+#############################################################################################
+#
+#  run_protogen_lulc_gbdxtools.py
+#
+#  Created by: Dave Loomis
+#              Digitalglobe GBD Solutions
+#
+#  Version 0.1: Jun 10, 2016
+#               - example of running protogen LULC with AOP input using gbdxtools
+#
+#  Usage: run_protogen_lulc_gbdxtools.py 
+#
+#
+#############################################################################################
+
+from gbdxtools import Interface
+gbdx = Interface()
+
+# get output dir from arg on the command line
+out_data_loc = "dloomis/lulc_wf_test"
+
+# set the input data location.  This could also be pulled from a catalog API response using a catalog_id
+data = "s3://receiving-dgcs-tdgplatform-com/055186940010_01_003/"
+
+# build the task used in the workflow
+aoptask = gbdx.Task("AOP_Strip_Processor", data=data, enable_acomp=True, enable_pansharpen=False,enable_dra=False,bands='MS')
+pp_task = gbdx.Task("ProtogenPrep",raster=aoptask.outputs.data.value)      # ProtogenPrep task is used to get AOP output into proper format for protogen task
+prot_lulc = gbdx.Task("protogenV2LULC",raster=pp_task.outputs.data.value)
+# build the workflow ( AOP -> ProtogenPrep -> protogenV2LULC )
+workflow = gbdx.Workflow([ aoptask,pp_task,prot_lulc ]) 
+workflow.savedata(prot_lulc.outputs.data.value, location=out_data_loc)
+
+# optional: print workflow tasks, to check the json 
+print
+print(aoptask.generate_task_workflow_json())
+print
+print(pp_task.generate_task_workflow_json())
+print
+print(prot_lulc.generate_task_workflow_json())
+print
+
+# kick off the workflow
+workflow.execute()
+
+# print out the workflow.status, this is one way to get the workflow id
+print
+print(workflow.status)

--- a/gbdxtools/catalog.py
+++ b/gbdxtools/catalog.py
@@ -79,7 +79,7 @@ class Catalog():
         lat, lng = self.get_address_coords(address)
         return self.search_point(lat,lng, type)
 
-    def search_point(self, lat, lng, type="Acquisition"):
+    def search_point(self, lat, lng, type="Acquisition", filters=None):
         ''' Perform a catalog search over a specific point, specified by lat,lng
 
         Args:
@@ -98,6 +98,10 @@ class Catalog():
                 type
             ]
         }
+        
+        if filters:
+            postdata['filters'] = filters
+
         url = 'https://geobigdata.io/catalog/v1/search?includeRelationships=false'
         headers = {'Content-Type':'application/json'}
         r = self.gbdx_connection.post(url, headers=headers, data=json.dumps(postdata))


### PR DESCRIPTION
This example will create an AOP ortho, place the AOP....tif in the correct location for protogen to find it, run protogenV2LULC and move it to user's private storage bucket.
