### PR TITLE
Refactor urls to allow alternate environment urls.

### DIFF
--- a/gbdxtools/catalog_search_aoi.py
+++ b/gbdxtools/catalog_search_aoi.py
@@ -75,7 +75,7 @@ def polygon_from_bounds( bounds ):
     W, S, E, N = bounds
     return geometry.Polygon(  ( (W,N),(E,N),(E,S),(W,S),(W,N) )  )
 
-def search_materials_in_multiple_small_searches(search_request, gbdx_connection):
+def search_materials_in_multiple_small_searches(search_request, gbdx_connection, base_url):
     D = 1.4  # the size in degrees of the side of a square that we will search
 
     searchAreaWkt = search_request['searchAreaWkt']
@@ -112,7 +112,9 @@ def search_materials_in_multiple_small_searches(search_request, gbdx_connection)
 
                 search_request['searchAreaWkt'] = subsearchpoly.wkt
 
-                url = 'https://geobigdata.io/catalog/v1/search?includeRelationships=false'
+                url = '%(base_url)s/search?includeRelationships=false' % {
+                    'base_url': base_url
+                }
                 headers = {'Content-Type':'application/json'}
                 r = gbdx_connection.post(url, headers=headers, data=json.dumps(search_request))
                 r.raise_for_status()

--- a/gbdxtools/idaho.py
+++ b/gbdxtools/idaho.py
@@ -30,6 +30,7 @@ class Idaho(object):
             An instance of the Idaho interface class.
 
         '''
+        self.base_url = '%s/catalog/v1' % interface.root_url
         self.gbdx_connection = interface.gbdx_connection
         self.catalog = Catalog(interface)
         self.logger = interface.logger
@@ -47,7 +48,7 @@ class Idaho(object):
         self.logger.debug('Retrieving IDAHO metadata')
 
         # use the footprint to get the IDAHO id
-        url = 'https://geobigdata.io/catalog/v1/search'
+        url = '%s/search' % self.base_url
 
         body = {"filters": ["vendorDatasetIdentifier3 = '%s'" % catid],
                 "types": ["IDAHOImage"],

--- a/gbdxtools/interface.py
+++ b/gbdxtools/interface.py
@@ -27,6 +27,9 @@ class Interface(object):
     gbdx_connection = None
 
     def __init__(self, **kwargs):
+        host = kwargs.get('host') if kwargs.get('host') else 'geobigdata.io'
+        self.root_url = 'https://%s' % host
+
         if (kwargs.get('username') and kwargs.get('password') and
                 kwargs.get('client_id') and kwargs.get('client_secret')):
             self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)

--- a/gbdxtools/ordering.py
+++ b/gbdxtools/ordering.py
@@ -21,6 +21,7 @@ class Ordering(object):
            Returns:
                An instance of the Ordering interface.
         '''
+        self.base_url = '%s/orders/v2' % interface.root_url
         self.gbdx_connection = interface.gbdx_connection
         self.logger = interface.logger
     
@@ -49,7 +50,7 @@ class Ordering(object):
                 results_list.append(order_id)
 
         self.logger.debug('Place order')
-        url = 'https://geobigdata.io/orders/v2/order/'
+        url = '%s/order' % self.base_url
 
         batch_size = min(100, batch_size)
         
@@ -88,8 +89,10 @@ class Ordering(object):
         '''
 
         self.logger.debug('Get status of order ' + order_id)
-        url = 'https://geobigdata.io/orders/v2/order/'
-        r = self.gbdx_connection.get(url + order_id)
+        url = '%(base_url)s/order/%(order_id)s' % {
+            'base_url': self.base_url, 'order_id': order_id
+        }
+        r = self.gbdx_connection.get(url)
         r.raise_for_status()
         return r.json().get("acquisitions", {})
 
@@ -101,7 +104,7 @@ class Ordering(object):
 
         Returns:  True or False
         '''
-        url = 'https://geobigdata.io/orders/v2/heartbeat'
+        url = '%s/heartbeat' % self.base_url
         # Auth is not required to hit the heartbeat
         r = requests.get(url) 
 
@@ -118,7 +121,7 @@ class Ordering(object):
             r.raise_for_status()
             results_dict['acquisitions'].extend(r.json()['acquisitions'])
 
-        url = 'https://geobigdata.io/orders/v2/location'
+        url = '%s/location' % self.base_url
 
         batch_size = min(100, batch_size)
 

--- a/gbdxtools/s3.py
+++ b/gbdxtools/s3.py
@@ -20,6 +20,8 @@ class S3(object):
             An instance of gbdxtools.S3.
 
         '''
+        self.base_url = '%s/s3creds/v1' % interface.root_url
+
         # store a ref to the GBDX connection
         self.gbdx_connection = interface.gbdx_connection
 
@@ -49,7 +51,7 @@ class S3(object):
             user bucket and user prefix (dict).
         '''
 
-        url = 'https://geobigdata.io/s3creds/v1/prefix?duration=36000'
+        url = '%s/prefix?duration=36000' % self.base_url
         r = self.gbdx_connection.get(url)
         r.raise_for_status()
         return r.json()

--- a/gbdxtools/task_registry.py
+++ b/gbdxtools/task_registry.py
@@ -9,7 +9,7 @@ import json
 
 class TaskRegistry(object):
     def __init__(self, interface):
-        self._base_url = 'https://geobigdata.io/workflows/v1/tasks'
+        self._base_url = '%s/workflows/v1/tasks' % interface.root_url
 
         # store a reference to the GBDX Connection
         self.gbdx_connection = interface.gbdx_connection

--- a/gbdxtools/workflow.py
+++ b/gbdxtools/workflow.py
@@ -21,6 +21,9 @@ class Workflow(object):
         Returns:
             An instance of the Workflow class.
         """
+        self.base_url = '%s/workflows/v1' % interface.root_url
+        self.workflows_url = '%s/workflows' % self.base_url
+
         # store a reference to the GBDX Connection
         self.gbdx_connection = interface.gbdx_connection
 
@@ -41,9 +44,8 @@ class Workflow(object):
         """
 
         # hit workflow api
-        url = 'https://geobigdata.io/workflows/v1/workflows'
         try:
-            r = self.gbdx_connection.post(url, json=workflow)
+            r = self.gbdx_connection.post(self.workflows_url, json=workflow)
             try:
                 r.raise_for_status()
             except:
@@ -65,7 +67,9 @@ class Workflow(object):
              Workflow status (str).
         """
         self.logger.debug('Get status of workflow: ' + workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id
+        url = '%(wf_url)s/%(wf_id)s' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id
+        }
         r = self.gbdx_connection.get(url)
 
         return r.json()['state']
@@ -80,7 +84,9 @@ class Workflow(object):
              Workflow object (dict).
         """
         self.logger.debug('Get workflow object: ' + workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id
+        url = '%(wf_url)s/%(wf_id)s' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id
+        }
         r = self.gbdx_connection.get(url)
         r.raise_for_status()
 
@@ -96,7 +102,9 @@ class Workflow(object):
          Returns:
              Stdout of the task (string).
         """
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id + '/tasks/' + task_id + '/stdout'
+        url = '%(wf_url)s/%(wf_id)s/tasks/%(task_id)s/stdout' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id, 'task_id': task_id
+        }
         r = self.gbdx_connection.get(url)
         r.raise_for_status()
 
@@ -112,7 +120,9 @@ class Workflow(object):
          Returns:
              Stderr of the task (string).
         """
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id + '/tasks/' + task_id + '/stderr'
+        url = '%(wf_url)s/%(wf_id)s/tasks/%(task_id)s/stderr' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id, 'task_id': task_id
+        }
         r = self.gbdx_connection.get(url)
         r.raise_for_status()
 
@@ -128,7 +138,9 @@ class Workflow(object):
              List of workflow events.
         '''
         self.logger.debug('Get events of workflow: ' + workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id + '/events'
+        url = '%(wf_url)s/%(wf_id)s/events' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id
+        }
         r = self.gbdx_connection.get(url)
 
         return r.json()['Events']
@@ -143,7 +155,9 @@ class Workflow(object):
                Nothing
         """
         self.logger.debug('Canceling workflow: ' + workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/workflows/' + workflow_id + '/cancel'
+        url = '%(wf_url)s/%(wf_id)s/cancel' % {
+            'wf_url': self.workflows_url, 'wf_id': workflow_id
+        }
         r = self.gbdx_connection.post(url, data='')
         r.raise_for_status()
 
@@ -158,7 +172,9 @@ class Workflow(object):
         """
 
         # hit workflow api
-        url = 'https://geobigdata.io/workflows/v1/batch_workflows'
+        url = '%(base_url)s/batch_workflows' % {
+            'base_url': self.base_url
+        }
         try:
             r = self.gbdx_connection.post(url, json=batch_workflow)
             batch_workflow_id = r.json()['batch_workflow_id']
@@ -176,7 +192,9 @@ class Workflow(object):
              Batch Workflow status (str).
         """
         self.logger.debug('Get status of batch workflow: ' + batch_workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/batch_workflows/' + batch_workflow_id
+        url = '%(base_url)s/batch_workflows/%(batch_id)s' % {
+            'base_url': self.base_url, 'batch_id': batch_workflow_id
+        }
         r = self.gbdx_connection.get(url)
 
         return r.json()
@@ -191,7 +209,9 @@ class Workflow(object):
              Batch Workflow status (str).
         """
         self.logger.debug('Cancel batch workflow: ' + batch_workflow_id)
-        url = 'https://geobigdata.io/workflows/v1/batch_workflows/{0}/cancel'.format(batch_workflow_id)
+        url = '%(base_url)s/batch_workflows/%(batch_id)s/cancel' % {
+            'base_url': self.base_url, 'batch_id': batch_workflow_id
+        }
         r = self.gbdx_connection.post(url)
 
         return r.json()

--- a/tests/unit/cassettes/test_order_multi_catids.yaml
+++ b/tests/unit/cassettes/test_order_multi_catids.yaml
@@ -8,7 +8,7 @@ interactions:
       Content-Length: ['40']
       User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://geobigdata.io/orders/v2/order/
+    uri: https://geobigdata.io/orders/v2/order
   response:
     body: {string: !!python/unicode '{"order_id": "2b3ba38e-4d7e-4ef6-ac9d-2e2e0a8ca1e7",
         "acquisitions": [{"acquisition_id": "101001000DB2FB00", "state": "delivered",

--- a/tests/unit/cassettes/test_order_single_catid.yaml
+++ b/tests/unit/cassettes/test_order_single_catid.yaml
@@ -8,7 +8,7 @@ interactions:
       Content-Length: ['20']
       User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://geobigdata.io/orders/v2/order/
+    uri: https://geobigdata.io/orders/v2/order
   response:
     body: {string: !!python/unicode '{"order_id": "c5cd8157-3001-4a03-a716-4ef673748c7a",
         "acquisitions": [{"acquisition_id": "10400100120FEA00", "state": "delivered",

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -1,4 +1,4 @@
-from gbdxtools import Interface
+import gbdxtools
 from auth_mock import get_mock_gbdx_session
 
 """
@@ -17,5 +17,25 @@ mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
 
 
 def test_init():
-    gi = Interface(gbdx_connection=mock_gbdx_session)
-    assert isinstance(gi, Interface)
+    gi = gbdxtools.Interface(gbdx_connection=mock_gbdx_session)
+    assert isinstance(gi, gbdxtools.Interface)
+
+
+def test_init_host(monkeypatch):
+    test_host = 'test.mydomain.com'
+
+    def session(config_file):
+        return None
+
+    monkeypatch.setattr(gbdxtools.interface.gbdx_auth, 'get_session', session)
+
+    gbdx = gbdxtools.Interface(host=test_host)
+    assert isinstance(gbdx, gbdxtools.Interface)
+    assert gbdx.root_url == 'https://%s' % test_host
+    assert gbdx.catalog.base_url == 'https://%s/catalog/v1' % test_host
+    assert gbdx.ordering.base_url == 'https://%s/orders/v2' % test_host
+    assert gbdx.idaho.base_url == 'https://%s/catalog/v1' % test_host
+    assert gbdx.s3.base_url == 'https://%s/s3creds/v1' % test_host
+    assert gbdx.task_registry._base_url == 'https://%s/workflows/v1/tasks' % test_host
+    assert gbdx.workflow.base_url == 'https://%s/workflows/v1' % test_host
+    assert gbdx.workflow.workflows_url == 'https://%s/workflows/v1/workflows' % test_host


### PR DESCRIPTION
This proposed change is to allow users (developers) to configure the gbdxtools Interface so it will hit endpoints in separate environments. 

Intention is the Interface `host` keyword argument will be used in conjunction with any of the custom session options. It will require the `auth_url` included in the session or the credentials be from the same environment, otherwise authentication errors will be returned from the endpoints.

I added an Interface unit test which shows use case with a custom config file.