### PR TITLE
Interface auth refactor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.10.0
+-----
+* refactored the way auth is handled in gbdxtools.interface into a singleton pattern to support direct importing of module classes. Classes can now auth themselves. 
+
 0.9.6
 -----
 * update gbdx.vectors.query() to be able to return more than 1000 results (uses paging service on the backend)

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -14,7 +14,6 @@ class _Auth(object):
     root_url = 'https://geobigdata.io'
 
     def __init__(self, **kwargs):
-        print 'init'
         self.logger = logging.getLogger('gbdxtools')
         self.logger.setLevel(logging.ERROR)
         self.console_handler = logging.StreamHandler()

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -1,27 +1,20 @@
 from gbdx_auth import gbdx_auth
 import logging
 
-class OnlyOne(object):
-    class __OnlyOne:
-        def __init__(self):
-            self.val = None
-        def __str__(self):
-            return `self` + self.val
-    instance = None
-    def __new__(cls): # __new__ always a classmethod
-        if not OnlyOne.instance:
-            OnlyOne.instance = OnlyOne.__OnlyOne()
-        return OnlyOne.instance
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
-    def __setattr__(self, name):
-        return setattr(self.instance, name)
+auth = None
 
-class Interface():
+def Auth(**kwargs):
+    global auth
+    if auth is None or len(kwargs) > 0:
+        auth = _Auth(**kwargs)
+    return auth
+        
+class _Auth(object):
     gbdx_connection = None
     root_url = 'https://geobigdata.io'
 
     def __init__(self, **kwargs):
+        print 'init'
         self.logger = logging.getLogger('gbdxtools')
         self.logger.setLevel(logging.ERROR)
         self.console_handler = logging.StreamHandler()
@@ -33,7 +26,7 @@ class Interface():
 
         if 'host' in kwargs:
             self.root_url = 'https://%s' % kwargs.get('host')
-        try:  
+        try:
             if (kwargs.get('username') and kwargs.get('password') and
                     kwargs.get('client_id') and kwargs.get('client_secret')):
                 self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
@@ -42,5 +35,7 @@ class Interface():
             elif self.gbdx_connection is None:
                 # This will throw an exception if your .ini file is not set properly
                 self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
-        except Exception as err: 
+        except Exception as err:
             print(err)
+    
+    

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -1,0 +1,46 @@
+from gbdx_auth import gbdx_auth
+import logging
+
+class OnlyOne(object):
+    class __OnlyOne:
+        def __init__(self):
+            self.val = None
+        def __str__(self):
+            return `self` + self.val
+    instance = None
+    def __new__(cls): # __new__ always a classmethod
+        if not OnlyOne.instance:
+            OnlyOne.instance = OnlyOne.__OnlyOne()
+        return OnlyOne.instance
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+    def __setattr__(self, name):
+        return setattr(self.instance, name)
+
+class Interface():
+    gbdx_connection = None
+    root_url = 'https://geobigdata.io'
+
+    def __init__(self, **kwargs):
+        self.logger = logging.getLogger('gbdxtools')
+        self.logger.setLevel(logging.ERROR)
+        self.console_handler = logging.StreamHandler()
+        self.console_handler.setLevel(logging.ERROR)
+        self.formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        self.console_handler.setFormatter(self.formatter)
+        self.logger.addHandler(self.console_handler)
+        self.logger.info('Logger initialized')
+
+        if 'host' in kwargs:
+            self.root_url = 'https://%s' % kwargs.get('host')
+        try:  
+            if (kwargs.get('username') and kwargs.get('password') and
+                    kwargs.get('client_id') and kwargs.get('client_secret')):
+                self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
+            elif kwargs.get('gbdx_connection'):
+                self.gbdx_connection = kwargs.get('gbdx_connection')
+            elif self.gbdx_connection is None:
+                # This will throw an exception if your .ini file is not set properly
+                self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
+        except Exception as err: 
+            print(err)

--- a/gbdxtools/catalog.py
+++ b/gbdxtools/catalog.py
@@ -11,17 +11,17 @@ import json
 import datetime
 from . import catalog_search_aoi
 
+from gbdxtools.auth import Auth
+
 class Catalog(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         ''' Construct the Catalog interface class
-
-        Args:
-            interface: A reference to the GBDX Interface.
 
         Returns:
             An instance of the Catalog interface class.
         '''
+        interface = Auth(**kwargs)
         self.base_url = '%s/catalog/v1' % interface.root_url
         self.gbdx_connection = interface.gbdx_connection
         self.logger = interface.logger

--- a/gbdxtools/idaho.py
+++ b/gbdxtools/idaho.py
@@ -16,23 +16,21 @@ import os
 import requests
 
 from gbdxtools.catalog import Catalog
-
+from gbdxtools.auth import Auth
 
 class Idaho(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         ''' Construct the Idaho interface class.
-
-        Args:
-            connection (gbdx_session): A reference to the GBDX Connection.
 
         Returns:
             An instance of the Idaho interface class.
 
         '''
+        interface = Auth(**kwargs)
         self.base_url = '%s/catalog/v1' % interface.root_url
         self.gbdx_connection = interface.gbdx_connection
-        self.catalog = Catalog(interface)
+        self.catalog = Catalog()
         self.logger = interface.logger
 
     def get_images_by_catid_and_aoi(self, catid, aoi_wkt):

--- a/gbdxtools/ordering.py
+++ b/gbdxtools/ordering.py
@@ -8,19 +8,17 @@ from builtins import object
 import requests
 import json
 
-
+from gbdxtools.auth import Auth
 
 class Ordering(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         '''Instantiate the GBDX Ordering Interface
-
-           Args:
-               interface (Interface): A reference to the GBDX interface.
 
            Returns:
                An instance of the Ordering interface.
         '''
+        interface = Auth(**kwargs)
         self.base_url = '%s/orders/v2' % interface.root_url
         self.gbdx_connection = interface.gbdx_connection
         self.logger = interface.logger

--- a/gbdxtools/s3.py
+++ b/gbdxtools/s3.py
@@ -7,19 +7,18 @@ import os
 from builtins import object
 
 from boto import s3 as botos3
+from gbdxtools.auth import Auth
 
 class S3(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         '''Instantiate the s3 interface
-
-        Args:
-            interface (Interface): A reference to the Interface that owns this instance.
 
         Returns:
             An instance of gbdxtools.S3.
 
         '''
+        interface = Auth(**kwargs)
         self.base_url = '%s/s3creds/v1' % interface.root_url
 
         # store a ref to the GBDX connection

--- a/gbdxtools/task_registry.py
+++ b/gbdxtools/task_registry.py
@@ -5,17 +5,19 @@ Contact: dmitry.zviagintsev@digitalglobe.com
 """
 
 import json
-
+from gbdxtools.auth import Auth
+from gbdxtools.s3 import S3
 
 class TaskRegistry(object):
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
+        interface = Auth(**kwargs)
         self._base_url = '%s/workflows/v1/tasks' % interface.root_url
 
         # store a reference to the GBDX Connection
         self.gbdx_connection = interface.gbdx_connection
 
         # store a ref to the s3 interface
-        self.s3 = interface.s3
+        self.s3 = S3()
 
         # the logger
         self.logger = interface.logger

--- a/gbdxtools/vectors.py
+++ b/gbdxtools/vectors.py
@@ -11,17 +11,17 @@ from pygeoif import geometry
 from geomet import wkt as wkt2geojson
 import json
 
+from gbdxtools.auth import Auth
+
 class Vectors(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         ''' Construct the Vectors interface class
-
-        Args:
-            interface: A reference to the GBDX Interface.
 
         Returns:
             An instance of the Vectors interface class.
         '''
+        interface = Auth(**kwargs)
         self.gbdx_connection = interface.gbdx_connection
         self.logger = interface.logger
         self.query_url = 'https://vector.geobigdata.io/insight-vector/api/vectors/query/paging'

--- a/gbdxtools/vectors.py
+++ b/gbdxtools/vectors.py
@@ -11,17 +11,17 @@ from pygeoif import geometry
 from geomet import wkt as wkt2geojson
 import json
 
+from gbdxtools.auth import Auth
+
 class Vectors(object):
 
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         ''' Construct the Vectors interface class
-
-        Args:
-            interface: A reference to the GBDX Interface.
 
         Returns:
             An instance of the Vectors interface class.
         '''
+        interface = Auth(**kwargs)
         self.gbdx_connection = interface.gbdx_connection
         self.logger = interface.logger
         self.query_url = 'https://vector.geobigdata.io/insight-vector/api/vectors/query/items'

--- a/gbdxtools/workflow.py
+++ b/gbdxtools/workflow.py
@@ -9,18 +9,17 @@ from __future__ import print_function
 from builtins import object
 
 import json
-
+from gbdxtools.auth import Auth
+from gbdxtools.s3 import S3
 
 class Workflow(object):
-    def __init__(self, interface):
+    def __init__(self, **kwargs):
         """Construct the Workflow instance
         
-        Args:
-            interface (Interface): A reference to the GBDX Interface.
-
         Returns:
             An instance of the Workflow class.
         """
+        interface = Auth(**kwargs)
         self.base_url = '%s/workflows/v1' % interface.root_url
         self.workflows_url = '%s/workflows' % self.base_url
 
@@ -28,7 +27,7 @@ class Workflow(object):
         self.gbdx_connection = interface.gbdx_connection
 
         # store a ref to the s3 interface
-        self.s3 = interface.s3
+        self.s3 = S3()
 
         # the logger
         self.logger = interface.logger

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info > (3,):
 # long_description=readme,
 
 setup(name='gbdxtools',
-      version='0.9.6',
+      version='0.10.0',
       description='Additional s3 functionality.',
       classifiers=[],
       keywords='',

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -31,19 +31,19 @@ class TestCatalog(unittest.TestCase):
         cls.gbdx = Interface(gbdx_connection=mock_gbdx_session)
 
     def test_init(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         self.assertTrue(isinstance(c, Catalog))
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_address_coords.yaml', filter_headers=['authorization'])
     def test_catalog_get_address_coords(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         lat, lng = c.get_address_coords('Boulder, CO')
         self.assertTrue(lat == 40.0149856)
         self.assertTrue(lng == -105.2705456)
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_record.yaml', filter_headers=['authorization'])
     def test_catalog_get_record(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         catid = '1040010019B4A600'
         record = c.get(catid)
 
@@ -54,7 +54,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_record_with_relationships.yaml', filter_headers=['authorization'])
     def test_catalog_get_record_with_relationships(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         catid = '1040010019B4A600'
         record = c.get(catid, includeRelationships=True)
 
@@ -66,7 +66,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_point.yaml', filter_headers=['authorization'])
     def test_catalog_search_point(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         lat = 40.0149856
         lng = -105.2705456
         results = c.search_point(lat, lng)
@@ -75,7 +75,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_address.yaml', filter_headers=['authorization'])
     def test_catalog_search_address(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         results = c.search_address('Boulder, CO')
 
         self.assertEqual(len(results), 310)
@@ -84,27 +84,27 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_wkt_only.yaml',filter_headers=['authorization'])
     def test_catalog_search_wkt_only(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         results = c.search(searchAreaWkt="POLYGON ((30.1 9.9, 30.1 10.1, 29.9 10.1, 29.9 9.9, 30.1 9.9))")
         assert len(results) == 395
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_wkt_and_startDate.yaml',filter_headers=['authorization'])
     def test_catalog_search_wkt_and_startDate(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         results = c.search(searchAreaWkt="POLYGON ((30.1 9.9, 30.1 10.1, 29.9 10.1, 29.9 9.9, 30.1 9.9))",
                            startDate='2012-01-01T00:00:00.000Z')
         assert len(results) == 317
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_wkt_and_endDate.yaml',filter_headers=['authorization'])
     def test_catalog_search_wkt_and_endDate(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         results = c.search(searchAreaWkt="POLYGON ((30.1 9.9, 30.1 10.1, 29.9 10.1, 29.9 9.9, 30.1 9.9))",
                            endDate='2012-01-01T00:00:00.000Z')
         assert len(results) == 78
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_startDate_and_endDate_only_more_than_one_week_apart.yaml',filter_headers=['authorization'])
     def test_catalog_search_startDate_and_endDate_only_more_than_one_week_apart(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         try:
             results = c.search(startDate='2004-01-01T00:00:00.000Z',
@@ -117,7 +117,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_startDate_and_endDate_only_less_than_one_week_apart.yaml',filter_headers=['authorization'])
     def test_catalog_search_startDate_and_endDate_only_less_than_one_week_apart(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         results = c.search(startDate='2008-01-01T00:00:00.000Z',
                                endDate='2008-01-03T00:00:00.000Z')
@@ -127,7 +127,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_filters1.yaml',filter_headers=['authorization'])
     def test_catalog_search_filters1(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         filters = [  
                         "(sensorPlatformName = 'WORLDVIEW01' OR sensorPlatformName ='QUICKBIRD02')",
@@ -147,7 +147,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_filters2.yaml',filter_headers=['authorization'])
     def test_catalog_search_filters2(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         filters = [  
                     "sensorPlatformName = 'WORLDVIEW03'"
@@ -161,7 +161,7 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_search_types1.yaml',filter_headers=['authorization'])
     def test_catalog_search_types1(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         types = [ "LandsatAcquisition" ]
 
@@ -176,7 +176,7 @@ class TestCatalog(unittest.TestCase):
         """
         Search an AOI the size of utah, broken into multiple smaller searches
         """
-        c = Catalog(self.gbdx)
+        c = Catalog()
 
         results = c.search(searchAreaWkt = "POLYGON((-113.88427734375 40.36642741921034,-110.28076171875 40.36642741921034,-110.28076171875 37.565262680889965,-113.88427734375 37.565262680889965,-113.88427734375 40.36642741921034))")
         
@@ -184,24 +184,24 @@ class TestCatalog(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_data_location_DG.yaml',filter_headers=['authorization'])
     def test_catalog_get_data_location_DG(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         s3path = c.get_data_location(catalog_id='1030010045539700')
         assert s3path == 's3://receiving-dgcs-tdgplatform-com/055158926010_01_003/055158926010_01'
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_data_location_Landsat.yaml',filter_headers=['authorization'])
     def test_catalog_get_data_location_Landsat(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         s3path = c.get_data_location(catalog_id='LC81740532014364LGN00')
         assert s3path == 's3://landsat-pds/L8/174/053/LC81740532014364LGN00'
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_data_location_nonexistent_catid.yaml',filter_headers=['authorization'])
     def test_catalog_get_data_location_nonexistent_catid(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         s3path = c.get_data_location(catalog_id='nonexistent_asdfasdfasdfdfasffds')
         assert s3path == None
 
     @vcr.use_cassette('tests/unit/cassettes/test_catalog_get_data_location_catid_with_no_data.yaml',filter_headers=['authorization'])
     def test_catalog_get_data_location_catid_with_no_data(self):
-        c = Catalog(self.gbdx)
+        c = Catalog()
         s3path = c.get_data_location(catalog_id='1010010011AD6E00')
         assert s3path == None

--- a/tests/unit/test_idaho.py
+++ b/tests/unit/test_idaho.py
@@ -34,12 +34,12 @@ class IdahoTest(unittest.TestCase):
         print("Created: {}".format(cls._temp_path))
 
     def test_init(self):
-        c = Idaho(self.gbdx)
+        c = Idaho()
         self.assertTrue(isinstance(c, Idaho))
 
     @vcr.use_cassette('tests/unit/cassettes/test_idaho_get_images_by_catid_and_aoi.yaml', filter_headers=['authorization'])
     def test_idaho_get_images_by_catid_and_aoi(self):
-        i = Idaho(self.gbdx)
+        i = Idaho()
         catid = '10400100203F1300'
         aoi_wkt = "POLYGON ((-105.0207996368408345 39.7338828628182839, -105.0207996368408345 39.7365972921260067, -105.0158751010894775 39.7365972921260067, -105.0158751010894775 39.7338828628182839, -105.0207996368408345 39.7338828628182839))"
         results = i.get_images_by_catid_and_aoi(catid=catid, aoi_wkt=aoi_wkt)
@@ -47,14 +47,14 @@ class IdahoTest(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_idaho_get_images_by_catid.yaml', filter_headers=['authorization'])
     def test_idaho_get_images_by_catid(self):
-        i = Idaho(self.gbdx)
+        i = Idaho()
         catid = '10400100203F1300'
         results = i.get_images_by_catid(catid=catid)
         assert len(results['results']) == 12
 
     @vcr.use_cassette('tests/unit/cassettes/test_idaho_describe_images.yaml', filter_headers=['authorization'])
     def test_idaho_describe_images(self):
-        i = Idaho(self.gbdx)
+        i = Idaho()
         catid = '10400100203F1300'
         description = i.describe_images(i.get_images_by_catid(catid=catid))
         assert description['10400100203F1300']['parts'][1]['PAN']['id'] =='b1f6448b-aecd-4d9b-99ec-9cad8d079043'

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -27,7 +27,7 @@ def test_init_host(monkeypatch):
     def session(config_file):
         return None
 
-    monkeypatch.setattr(gbdxtools.interface.gbdx_auth, 'get_session', session)
+    monkeypatch.setattr(gbdxtools.auth.gbdx_auth, 'get_session', session)
 
     gbdx = gbdxtools.Interface(host=test_host)
     assert isinstance(gbdx, gbdxtools.Interface)

--- a/tests/unit/test_ordering.py
+++ b/tests/unit/test_ordering.py
@@ -31,26 +31,26 @@ class OrderingTests(unittest.TestCase):
         cls.gbdx = Interface(gbdx_connection=mock_gbdx_session)
 
     def test_init(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         assert isinstance(o, Ordering)
 
     @vcr.use_cassette('tests/unit/cassettes/test_order_single_catid.yaml', filter_headers=['authorization'])
     def test_order_single_catid(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         order_id = o.order('10400100120FEA00')
         # assert order_id == 'c5cd8157-3001-4a03-a716-4ef673748c7a'
         assert len(order_id) == 36
 
     @vcr.use_cassette('tests/unit/cassettes/test_order_multi_catids.yaml', filter_headers=['authorization'])
     def test_order_multi_catids(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         order_id = o.order(['10400100120FEA00', '101001000DB2FB00'])
         # assert order_id == '2b3ba38e-4d7e-4ef6-ac9d-2e2e0a8ca1e7'
         assert len(order_id) == 36
 
     @vcr.use_cassette('tests/unit/cassettes/test_order_batching.yaml', filter_headers=['authorization'])
     def test_order_batching(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         order_id = o.order(['10400100120FEA00', '101001000DB2FB00'], batch_size=1)
         # assert order_id == '2b3ba38e-4d7e-4ef6-ac9d-2e2e0a8ca1e7'
         assert len(order_id) == 2
@@ -58,7 +58,7 @@ class OrderingTests(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_get_order_status.yaml', filter_headers=['authorization'])
     def test_get_order_status(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         results = o.status('c5cd8157-3001-4a03-a716-4ef673748c7a')
         print(results)
         for result in results:
@@ -68,7 +68,7 @@ class OrderingTests(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_image_location.yaml', filter_headers=['authorization'])
     def test_order_batching(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         res = o.location(['10400100120FEA00', '101001000DB2FB00'], batch_size=1)
         acq_list = res['acquisitions']
         assert len(acq_list) == 2
@@ -77,13 +77,13 @@ class OrderingTests(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_heartbeat.yaml', filter_headers=['authorization'])
     def test_heartbeat(self):
-        o = Ordering(self.gbdx)
+        o = Ordering()
         assert o.heartbeat() == True
 
     def test_heartbeat_failure(self):
         # mock requests.get so that we get a result for which response.json() will throw an exception
         with patch('gbdxtools.ordering.requests.get', return_value = False) as mock_within:
-            o = Ordering(self.gbdx)
+            o = Ordering()
             assert o.heartbeat() == False
 
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -33,12 +33,12 @@ class S3Tests(unittest.TestCase):
         print("Created: {}".format(cls._temp_path))
 
     def test_bucket_init(self):
-        s = S3(self.gbdx)
+        s = S3()
         assert isinstance(s, S3)
 
     @vcr.use_cassette('tests/unit/cassettes/test_get_s3creds.yaml', filter_headers=['authorization'])
     def test_get_s3_creds(self):
-        s = S3(self.gbdx)
+        s = S3()
         assert s.info is not None
         assert "bucket" in s.info.keys()
         assert "prefix" in s.info.keys()
@@ -49,7 +49,7 @@ class S3Tests(unittest.TestCase):
     @vcr.use_cassette(cassette_name, filter_headers=['authorization'])
     def test_download(self):
         location = 'nikki/gbdxtools_test_s3'
-        s = S3(self.gbdx)
+        s = S3()
         s.download(location, local_dir=self._temp_path)
 
         assert os.path.isfile(os.path.join(self._temp_path, 'test_dir', 'model.json'))

--- a/tests/unit/test_simpleworkflow.py
+++ b/tests/unit/test_simpleworkflow.py
@@ -284,7 +284,7 @@ class SimpleWorkflowTests(unittest.TestCase):
 
         w.execute()
 
-        wf_api = WorkflowAPI(self.gbdx)
+        wf_api = WorkflowAPI()
         wf_body = wf_api.get(w.id)
         assert wf_body['callback'] == callback_url
 

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -22,13 +22,13 @@ gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 
 def test_init():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
     assert isinstance(tr, TaskRegistry)
 
 
 @vcr.use_cassette('tests/unit/cassettes/test_list_tasks.yaml',filter_headers=['authorization'])
 def test_list_tasks():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
     task_list = tr.list()
     assert task_list is not None
     assert 'HelloGBDX' in task_list
@@ -36,7 +36,7 @@ def test_list_tasks():
 
 @vcr.use_cassette('tests/unit/cassettes/test_describe_tasks.yaml',filter_headers=['authorization'])
 def test_describe_tasks():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
     task_list = tr.list()
     assert len(task_list) > 0
     desc = tr.get_definition(task_list[0])
@@ -46,7 +46,7 @@ def test_describe_tasks():
 
 @vcr.use_cassette('tests/unit/cassettes/test_register_task.yaml',filter_headers=['authorization'])
 def _test_register_task(task_json=None, filename=None):
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
 
     if task_json:
         rv = tr.register(task_json)
@@ -94,7 +94,7 @@ def test_register_task_from_file():
 
 
 def test_register_fails_when_both_json_and_file():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
 
     try:
         tr.register(task_json={'any': 'thing'}, json_filename="any")
@@ -106,7 +106,7 @@ def test_register_fails_when_both_json_and_file():
 
 
 def test_register_fails_when_both_json_and_file_none():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
 
     try:
         tr.register(task_json=None, json_filename=None)
@@ -119,7 +119,7 @@ def test_register_fails_when_both_json_and_file_none():
 
 @vcr.use_cassette('tests/unit/cassettes/test_delete_task.yaml',filter_headers=['authorization'])
 def test_delete_task():
-    tr = TaskRegistry(gbdx)
+    tr = TaskRegistry()
     tasks = tr.list()
     if not 'gbdxtools-test-task' in tasks:
         test_list_tasks()

--- a/tests/unit/test_vectors.py
+++ b/tests/unit/test_vectors.py
@@ -31,12 +31,12 @@ class TestVectors(unittest.TestCase):
         cls.gbdx = Interface(gbdx_connection=mock_gbdx_session)
 
     def test_init(self):
-        c = Vectors(self.gbdx)
+        c = Vectors()
         self.assertTrue(isinstance(c, Vectors))
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_search.yaml', filter_headers=['authorization'], match_on=['method', 'scheme', 'host', 'port', 'path'])
     def test_vectors_search(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         aoi = "POLYGON((17.75390625 25.418470119273117,24.08203125 25.418470119273117,24.08203125 19.409611549990895,17.75390625 19.409611549990895,17.75390625 25.418470119273117))"
         results = v.query(aoi, query="item_type:WV03")
 
@@ -57,7 +57,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_single.yaml', filter_headers=['authorization'])
     def test_vectors_create_single(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         results = v.create({
             "type": "Feature",
                 "geometry": {
@@ -82,7 +82,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_multiple.yaml', filter_headers=['authorization'])
     def test_vectors_create_multiple(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         results = v.create([{
             "type": "Feature",
                 "geometry": {
@@ -124,7 +124,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_from_wkt.yaml', filter_headers=['authorization'])
     def test_vectors_create_from_wkt(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
 
         aoi = "POLYGON((0 3,3 3,3 0,0 0,0 3))"
         result = v.create_from_wkt(

--- a/tests/unit/test_vectors.py
+++ b/tests/unit/test_vectors.py
@@ -44,7 +44,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_search.yaml', filter_headers=['authorization'], match_on=['method', 'scheme', 'host', 'port', 'path'])
     def test_vectors_search_iteratively(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         aoi = "POLYGON((17.75390625 25.418470119273117,24.08203125 25.418470119273117,24.08203125 19.409611549990895,17.75390625 19.409611549990895,17.75390625 25.418470119273117))"
         g = v.query_iteratively(aoi, query="item_type:WV03")
 

--- a/tests/unit/test_vectors.py
+++ b/tests/unit/test_vectors.py
@@ -30,12 +30,12 @@ class TestVectors(unittest.TestCase):
         cls.gbdx = Interface(gbdx_connection=mock_gbdx_session)
 
     def test_init(self):
-        c = Vectors(self.gbdx)
+        c = Vectors()
         self.assertTrue(isinstance(c, Vectors))
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_search.yaml', filter_headers=['authorization'])
     def test_vectors_search(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         aoi = "POLYGON((17.75390625 25.418470119273117,24.08203125 25.418470119273117,24.08203125 19.409611549990895,17.75390625 19.409611549990895,17.75390625 25.418470119273117))"
         results = v.query(aoi, query="item_type:WV03")
 
@@ -43,7 +43,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_single.yaml', filter_headers=['authorization'])
     def test_vectors_create_single(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         results = v.create({
             "type": "Feature",
                 "geometry": {
@@ -68,7 +68,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_multiple.yaml', filter_headers=['authorization'])
     def test_vectors_create_multiple(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
         results = v.create([{
             "type": "Feature",
                 "geometry": {
@@ -110,7 +110,7 @@ class TestVectors(unittest.TestCase):
 
     @vcr.use_cassette('tests/unit/cassettes/test_vectors_create_from_wkt.yaml', filter_headers=['authorization'])
     def test_vectors_create_from_wkt(self):
-        v = Vectors(self.gbdx)
+        v = Vectors()
 
         aoi = "POLYGON((0 3,3 3,3 0,0 0,0 3))"
         result = v.create_from_wkt(

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -43,7 +43,7 @@ class WorkflowTests(unittest.TestCase):
         pass
 
     def test_init(self):
-        wf = Workflow(self.gbdx)
+        wf = Workflow()
         self.assertTrue(isinstance(wf, Workflow))
         self.assertTrue(wf.s3 is not None)
         self.assertTrue(wf.gbdx_connection is not None)
@@ -54,7 +54,7 @@ class WorkflowTests(unittest.TestCase):
         tests all 3 endpoints for batch workflows, create, fetch, and cancel
         :return:
         """
-        wf = Workflow(self.gbdx)
+        wf = Workflow()
 
         with open(os.path.join(self.data_path, "batch_workflow.json")) as json_file:
             self.batch_workflow_json = json.loads(json_file.read())
@@ -79,7 +79,7 @@ class WorkflowTests(unittest.TestCase):
         """
         test gbdx.workflows.get(<workflow_id>)
         """
-        wf = Workflow(self.gbdx)
+        wf = Workflow()
 
         output = wf.get('4488969848362445219')
 
@@ -95,7 +95,7 @@ class WorkflowTests(unittest.TestCase):
         """
         test gbdx.workflows.get_stdout(<workflow_id>,<task_id>)
         """
-        wf = Workflow(self.gbdx)
+        wf = Workflow()
 
         output = wf.get_stdout('4488969848362445219','4488969848354891944')
 
@@ -106,7 +106,7 @@ class WorkflowTests(unittest.TestCase):
         """
         test gbdx.workflows.get_stdout(<workflow_id>,<task_id>)
         """
-        wf = Workflow(self.gbdx)
+        wf = Workflow()
 
         output = wf.get_stderr('4488969848362445219','4488969848354891944')
 


### PR DESCRIPTION
This PR changes the way auth interfaces are handled and created in gbdxtools. the primary goal is to make it possible to run something like: 

```
from gbdxtools.vectors import Vectors

vectors = Vectors()
vectors.query(...)
```
Where a user *could* choose to pass auth creds into any of the class constructors. If they dont, then the normal gbdx-auth work flow operates as normal and creds are looked for in ENV vars or a config file. 

The usual `gbdx = Interface()` works as normal as well and all test pass. 

One question is how do we want to document this? I could produce a notebook with examples of calling various services directly instead of behind the `interface` but I wasnt sure if we wanted to to a full on change to every example and doc. 