### PR TITLE
Add task definition update function

### DIFF
--- a/gbdxtools/task_registry.py
+++ b/gbdxtools/task_registry.py
@@ -82,3 +82,18 @@ class TaskRegistry(object):
         r.raise_for_status()
 
         return r.text
+
+    def update(self, task_name, task_json):
+        """Updates a GBDX task.
+
+        Args:
+            task_name (str): Task name.
+            task_json (dict): Dictionary representing updated task definition.
+
+        Returns:
+            Dictionary representing the updated task definition.
+        """
+        r = self.gbdx_connection.put(self._base_url + '/' + task_name, json=task_json)
+        r.raise_for_status()
+
+        return r.json()

--- a/tests/unit/cassettes/test_update_task.yaml
+++ b/tests/unit/cassettes/test_update_task.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: !!python/unicode '{"containerDescriptors": [{"command": "", "type": "DOCKER",
+      "properties": {"image": "michaelconnor00/maptiks-alpine-base"}}], "description":
+      "Test task", "inputPortDescriptors": [{"type": "string", "description": "A string
+      input.", "name": "inputstring"}], "version": "0.0.1", "outputPortDescriptors":
+      [{"type": "string", "name": "output"}, {"type": "string", "name": "output1"}],
+      "name": "gbdxtools-test-task"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['411']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.12.1]
+    method: PUT
+    uri: https://geobigdata.io/workflows/v1/tasks/gbdxtools-test-task:0.0.1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42QP0/DMBDFv4rluQkuCxIbokwdWlVsiMFJjnCq/8l3QaDI3x3bSSVUBtjsu/d+
+        7/Rm2XvHGh3EHVAfMbCPJO/Fy5w31mo35I+UGyH5K0B57w6P+6dTmYToA0RGKIZZotVjVVjs3zWY
+        THY+KnVjdWA8U6NNyEFNpwlkSq+ZMKyZ6F0xPgOxYE3nQkcXJj76yL8Ou1xCHNGNRXvFeRDLSlRG
+        WxRO2+qpk9VYT/iASKtNtardFrGf+P/ZF/Jikmkj/lZtl+zrAuk4dQb7/HnThqCUjhayJU/ubpVK
+        P0BjN3yy94Yazq01tbX0DdGYM7fPAQAA
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-encoding: [gzip]
+      content-length: ['252']
+      content-type: [application/json]
+      date: ['Wed, 15 Mar 2017 20:57:10 GMT']
+      server: [nginx/1.8.0]
+      via: [kong/0.5.2]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -18,7 +18,7 @@ from auth_mock import get_mock_gbdx_session
 # 5. replace the real gbdx token with "dummytoken" again
 # 6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
 mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
-gbdx = Interface(gbdx_connection = mock_gbdx_session)
+gbdx = Interface(gbdx_connection=mock_gbdx_session)
 
 
 def test_init():
@@ -26,7 +26,7 @@ def test_init():
     assert isinstance(tr, TaskRegistry)
 
 
-@vcr.use_cassette('tests/unit/cassettes/test_list_tasks.yaml',filter_headers=['authorization'])
+@vcr.use_cassette('tests/unit/cassettes/test_list_tasks.yaml', filter_headers=['authorization'])
 def test_list_tasks():
     tr = TaskRegistry(gbdx)
     task_list = tr.list()
@@ -34,17 +34,17 @@ def test_list_tasks():
     assert 'HelloGBDX' in task_list
 
 
-@vcr.use_cassette('tests/unit/cassettes/test_describe_tasks.yaml',filter_headers=['authorization'])
+@vcr.use_cassette('tests/unit/cassettes/test_describe_tasks.yaml', filter_headers=['authorization'])
 def test_describe_tasks():
     tr = TaskRegistry(gbdx)
     task_list = tr.list()
     assert len(task_list) > 0
     desc = tr.get_definition(task_list[0])
     assert isinstance(desc, dict)
-    assert len(desc['description']) > 0   
+    assert len(desc['description']) > 0
 
 
-@vcr.use_cassette('tests/unit/cassettes/test_register_task.yaml',filter_headers=['authorization'])
+@vcr.use_cassette('tests/unit/cassettes/test_register_task.yaml', filter_headers=['authorization'])
 def _test_register_task(task_json=None, filename=None):
     tr = TaskRegistry(gbdx)
 
@@ -56,8 +56,8 @@ def _test_register_task(task_json=None, filename=None):
     assert 'successfully registered' in rv.lower()
 
 
-def test_register_task_from_json():
-    task_json = {
+def _task_json():
+    return {
         "inputPortDescriptors": [
             {
                 "description": "A string input.",
@@ -81,16 +81,41 @@ def test_register_task_from_json():
             }
         ],
         "description": "Test task",
-        "name": "gbdxtools-test-task"
+        "name": "gbdxtools-test-task",
+        "version": "0.0.1"
     }
+
+
+def test_register_task_from_json():
+    task_json = _task_json()
 
     _test_register_task(task_json=task_json)
 
 
 def test_register_task_from_file():
-    filename = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/gbdxtools_test_task.json"))
+    filename = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "gbdxtools_test_task.json"
+    ))
 
     _test_register_task(filename=filename)
+
+
+@vcr.use_cassette('tests/unit/cassettes/test_update_task.yaml', filter_headers=['authorization'])
+def test_update_task_definition():
+    # Note that this test requires the task to be registered all ready.
+    # If updating the VCR yaml cassette, manually register the gbdxtools-test-task above,
+    # Deleting it once the VCR cassette has been created.
+    tr = TaskRegistry(gbdx)
+
+    updated_task = _task_json()
+    output_ports = updated_task['outputPortDescriptors']
+    updated_task['outputPortDescriptors'] = output_ports + [{"name": "output%s" % len(output_ports), "type": "string"}]
+
+    task_name = '%s:%s' % (updated_task['name'], updated_task['version'])
+
+    r = tr.update(task_name, updated_task)
+
+    assert r['outputPortDescriptors'] == updated_task['outputPortDescriptors']
 
 
 def test_register_fails_when_both_json_and_file():


### PR DESCRIPTION
The `task_registry.py` module was missing function for updating a task definition using a PUT request. Added an update function to cover this functionality. 

Ref: http://gbdxdocs.digitalglobe.com/docs/how-to-version-a-task#section-updating-a-task-with-a-put-request
