### PR TITLE
Replace pycurl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ env:
     - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-  #- sudo apt update
+  - sudo apt -qq update
   #- sudo apt upgrade
   - sudo apt-get install -y python-dev libgdal1h libgdal-dev gdal-bin python-gdal
   - export CFLAGS=$(gdal-config --cflags)
+  - export
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
     - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-  - sudo apt update
-  - sudo apt upgrade
-  - sudo apt-get install -y libgdal-dev gdal-bin python-gdal
+  #- sudo apt update
+  #- sudo apt upgrade
+  - sudo apt-get install -y python-dev libgdal-dev gdal-bin python-gdal
   - export CFLAGS=$(gdal-config --cflags)
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,13 @@ install:
   #- wget https://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
   #- tar -xzvf protobuf-2.4.1.tar.gz
   #- pushd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install && popd
-  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
-  - export C_INCLUDE_PATH=/usr/include/gdal
-  - sudo pip install --download GDAL
-  - cd /tmp/pip_build_root/GDAL
-  - sudo python setup.py build_ext --include-dirs=/usr/include/gdal
-  - sudo pip install --no-download GDAL
+  #- export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  #- export C_INCLUDE_PATH=/usr/include/gdal
+  #- sudo pip install --download GDAL
+  #- cd /tmp/pip_build_root/GDAL
+  #- sudo python setup.py build_ext --include-dirs=/usr/include/gdal
+  #- sudo pip install --no-download GDAL
+  - CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal pip install GDAL==`gdal-config --version`
   - pip install -r requirements.txt coverage
 # command to run tests
 script: coverage run unit_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,14 @@ env:
     - CPLUS_INCLUDE_PATH=/usr/include/gdal
     - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
-  - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-  - sudo apt -qq update
-  #- sudo apt upgrade
+  #- sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+  #- sudo apt -qq update
   - sudo apt-get install -y python-dev libgdal1h libgdal-dev gdal-bin python-gdal
   - export CFLAGS=$(gdal-config --cflags)
   - export
 # command to install dependencies
 install:
-  - pip install -r requirements.txt coverage
+  - pip install --no-use-wheel -r requirements.txt coverage
 # command to run tests
 script: coverage run unit_tests.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - BOTO_CONFIG=/doesnotexist
 before_install: 
-  - sudo apt-get install -y libgdal1h gdal-bin
+  - sudo apt-get install -y libgdal1h gdal-bin python-gdal python3-gdal
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python:
 env:
   global:
     - BOTO_CONFIG=/doesnotexist
+    - CPLUS_INCLUDE_PATH=/usr/include/gdal
+    - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
   - sudo apt-get install -y libgdal-dev libgdal1h gdal-bin
-  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
-  - export C_INCLUDE_PATH=/usr/include/gdal
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-#  - "3.3"
-#  - "3.4"
-#  - "3.5"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 env:
   global:
     - BOTO_CONFIG=/doesnotexist
@@ -11,9 +11,6 @@ before_install:
   - sudo apt-get install -y libgdal1h libgdal-dev gdal-bin
 # command to install dependencies
 install:
-  #- wget https://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
-  #- tar -xzvf protobuf-2.4.1.tar.gz
-  #- pushd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install && popd
   - CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal pip install GDAL==`gdal-config --version`
   - pip install -r requirements.txt coverage
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   #- sudo apt update
   #- sudo apt upgrade
-  - sudo apt-get install -y python-dev libgdal-dev gdal-bin python-gdal
+  - sudo apt-get install -y python-dev libgdal1h libgdal-dev gdal-bin python-gdal
   - export CFLAGS=$(gdal-config --cflags)
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 # command to install dependencies
 install:
   - pip install pygdal==1.10.0
-  - pip install -r requirements.txt coverage --no-install gdal
+  - pip install -r requirements.txt coverage
 # command to run tests
 script: coverage run unit_tests.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - export
 # command to install dependencies
 install:
-  - pip install --no-use-wheel -r requirements.txt coverage
+  - pip install pygdal==1.10.0
+  - pip install -r requirements.txt coverage --no-install gdal
 # command to run tests
 script: coverage run unit_tests.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ python:
 env:
   global:
     - BOTO_CONFIG=/doesnotexist
-    - CPLUS_INCLUDE_PATH=/usr/include/gdal
-    - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
-  #- sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-  #- sudo apt -qq update
-  - sudo apt-get install -y python-dev libgdal1h libgdal-dev gdal-bin python-gdal
-  - export CFLAGS=$(gdal-config --cflags)
-  - export
+  - sudo apt-get install -y libgdal1h libgdal-dev gdal-bin
 # command to install dependencies
 install:
   - pip install pygdal==1.10.0
+  #- export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  #- export C_INCLUDE_PATH=/usr/include/gdal
+  #- sudo pip install --no-install GDAL
+  #- cd /tmp/pip_build_root/GDAL
+  #- sudo python setup.py build_ext --include-dirs=/usr/include/gdal
+  #- sudo pip install --no-download GDAL
   - pip install -r requirements.txt coverage
 # command to run tests
 script: coverage run unit_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ env:
     - CPLUS_INCLUDE_PATH=/usr/include/gdal
     - C_INCLUDE_PATH=/usr/include/gdal
 before_install: 
-  - sudo apt-get install -y libgdal-dev libgdal1h gdal-bin
+  - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+  - sudo apt update
+  - sudo apt upgrade
+  - sudo apt-get install -y libgdal-dev gdal-bin python-gdal
+  - export CFLAGS=$(gdal-config --cflags)
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+#  - "3.3"
+#  - "3.4"
+#  - "3.5"
 env:
   global:
     - BOTO_CONFIG=/doesnotexist
@@ -11,13 +11,16 @@ before_install:
   - sudo apt-get install -y libgdal1h libgdal-dev gdal-bin
 # command to install dependencies
 install:
-  - pip install pygdal==1.10.0
-  #- export CPLUS_INCLUDE_PATH=/usr/include/gdal
-  #- export C_INCLUDE_PATH=/usr/include/gdal
-  #- sudo pip install --no-install GDAL
-  #- cd /tmp/pip_build_root/GDAL
-  #- sudo python setup.py build_ext --include-dirs=/usr/include/gdal
-  #- sudo pip install --no-download GDAL
+  #- pip install pygdal==1.10.0
+  #- wget https://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
+  #- tar -xzvf protobuf-2.4.1.tar.gz
+  #- pushd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install && popd
+  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  - export C_INCLUDE_PATH=/usr/include/gdal
+  - sudo pip install --download GDAL
+  - cd /tmp/pip_build_root/GDAL
+  - sudo python setup.py build_ext --include-dirs=/usr/include/gdal
+  - sudo pip install --no-download GDAL
   - pip install -r requirements.txt coverage
 # command to run tests
 script: coverage run unit_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - BOTO_CONFIG=/doesnotexist
 before_install: 
-  - sudo apt-get install -y libgdal1h gdal-bin python-gdal python3-gdal
+  - sudo apt-get install -y libgdal-dev libgdal1h gdal-bin
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,9 @@ before_install:
   - sudo apt-get install -y libgdal1h libgdal-dev gdal-bin
 # command to install dependencies
 install:
-  #- pip install pygdal==1.10.0
   #- wget https://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
   #- tar -xzvf protobuf-2.4.1.tar.gz
   #- pushd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install && popd
-  #- export CPLUS_INCLUDE_PATH=/usr/include/gdal
-  #- export C_INCLUDE_PATH=/usr/include/gdal
-  #- sudo pip install --download GDAL
-  #- cd /tmp/pip_build_root/GDAL
-  #- sudo python setup.py build_ext --include-dirs=/usr/include/gdal
-  #- sudo pip install --no-download GDAL
   - CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal pip install GDAL==`gdal-config --version`
   - pip install -r requirements.txt coverage
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - BOTO_CONFIG=/doesnotexist
 before_install: 
   - sudo apt-get install -y libgdal-dev libgdal1h gdal-bin
+  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  - export C_INCLUDE_PATH=/usr/include/gdal
 # command to install dependencies
 install:
   - pip install -r requirements.txt coverage

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Make sure you have the latest pip version::
 
 **Ubuntu users**
 
-If you run into trouble with the installation of `cryptography` or `pycurl`, make sure that the following dependencies are installed::
+If you run into trouble with the installation of `cryptography`, make sure that the following dependencies are installed::
 
    sudo apt-get install build-essential libssl-dev libffi-dev python-dev libcurl4-openssl-dev
 
@@ -133,10 +133,6 @@ Activate the environment::
 Upgrade pip (if required)::
 
    pip install pip --upgrade
-
-Recent versions of gbdxtools require newish versions of pycurl. If you see pycurl version errors when you `pip install gbdxtools` try installing a new curl version in your conda environment:
-
-  conda install curl
 
 Install gbdxtools::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ MOCK_MODULES = ['json',
                 'requests.packages.urllib3',
                 'requests.packages.urllib3.exceptions',
                 'gbdx_auth',
-                'pycurl',
+                'gdal',
                 'numpy',
                 'rasterio']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/gbdxtools/images/ipe_image.py
+++ b/gbdxtools/images/ipe_image.py
@@ -53,8 +53,6 @@ num_workers = int(os.environ.get("GBDX_THREADS", 4))
 threaded_get = partial(dask.threaded.get, num_workers=num_workers)
 
 import requests
-import pycurl
-_curl_pool = defaultdict(pycurl.Curl)
 
 from gbdxtools.ipe.vrt import get_cached_vrt, put_cached_vrt, generate_vrt_template
 from gbdxtools.ipe.util import calc_toa_gain_offset, timeit
@@ -66,22 +64,12 @@ ipe = Ipe()
 
 def load_url(url, token, bands=8):
     """ Loads a geotiff url inside a thread and returns as an ndarray """
-    thread_id = threading.current_thread().ident
-    _curl = _curl_pool[thread_id]
-    buf = BytesIO()
-    _curl.setopt(_curl.URL, url)
-    _curl.setopt(_curl.WRITEDATA, buf)
-    _curl.setopt(pycurl.NOSIGNAL, 1)
-    _curl.setopt(pycurl.HTTPHEADER, ['Authorization: Bearer {}'.format(token)])
-    _curl.perform()
-    with MemoryFile(buf.getvalue()) as memfile:
-      try:
-          with memfile.open(driver="GTiff") as dataset:
-              arr = dataset.read()
-      except (TypeError, rasterio.RasterioIOError) as e:
-          arr = np.zeros([bands,256,256], dtype=np.float32)
-          _curl.close()
-          del _curl_pool[thread_id]
+    try:
+        src = gdal.Open('/vsicurl/{}?token={}'.format(url, token))
+        arr = src.ReadAsArray()
+    except Exception as e:
+        print(e, url, '/vsicurl/{}?token={}'.format(url, token))
+        arr = np.zeros([bands,256,256], dtype=np.float32)
     return arr
 
 class DaskImage(da.Array):

--- a/gbdxtools/images/ipe_image.py
+++ b/gbdxtools/images/ipe_image.py
@@ -34,6 +34,7 @@ from shapely.wkt import loads
 import rasterio
 from rasterio.io import MemoryFile
 from affine import Affine
+import gdal
 
 try:
   from matplotlib import pyplot as plt

--- a/gbdxtools/images/ipe_image.py
+++ b/gbdxtools/images/ipe_image.py
@@ -68,6 +68,8 @@ def load_url(url, token, bands=8):
     try:
         src = gdal.Open('/vsicurl/{}?token={}'.format(url, token))
         arr = src.ReadAsArray()
+        if len(arr.shape) != 3:
+            arr = np.reshape(arr, (1,) + arr.shape)
     except Exception as e:
         print(e, url, '/vsicurl/{}?token={}'.format(url, token))
         arr = np.zeros([bands,256,256], dtype=np.float32)

--- a/gbdxtools/images/ipe_image.py
+++ b/gbdxtools/images/ipe_image.py
@@ -34,7 +34,10 @@ from shapely.wkt import loads
 import rasterio
 from rasterio.io import MemoryFile
 from affine import Affine
-import gdal
+try:
+    import gdal
+except: 
+    from osgeo import gdal
 
 try:
   from matplotlib import pyplot as plt

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ toolz
 dask==0.13.0
 cloudpickle
 numpy
-pycurl
+gdal
 rasterio==1.0a3
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ toolz
 dask==0.13.0
 cloudpickle
 numpy
-pygdal
+gdal
 rasterio==1.0a3
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ toolz
 dask==0.13.0
 cloudpickle
 numpy
-gdal
+pygdal
 rasterio==1.0a3
 pyproj

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='gbdxtools',
                         'toolz',
                         'dask==0.13.0',
                         'cloudpickle',
-                        'pycurl',
+                        'gdal',
                         'rasterio>=1.0a3',
                         'pyproj'
                         ],


### PR DESCRIPTION
Pycurl is the source several issues, mostly dealing with installation. This PR removes pycurl in favor of using the gdal python bindings and `vsicurl` to fetching tiles from IPE. We've kicked the tires on this branch for a bit and i think its ready to be merged.