### PR TITLE
Image meta errors

### DIFF
--- a/gbdxtools/images/ipe_image.py
+++ b/gbdxtools/images/ipe_image.py
@@ -62,7 +62,7 @@ _curl_pool = defaultdict(pycurl.Curl)
 from gbdxtools.ipe.vrt import get_cached_vrt, put_cached_vrt, generate_vrt_template
 from gbdxtools.ipe.util import calc_toa_gain_offset, timeit
 from gbdxtools.ipe.graph import VIRTUAL_IPE_URL, register_ipe_graph, get_ipe_metadata, get_ipe_graph
-from gbdxtools.ipe.error import NotFound
+from gbdxtools.ipe.error import NotFound, BadRequest
 from gbdxtools.ipe.interface import Ipe
 from gbdxtools.auth import Auth
 ipe = Ipe()
@@ -174,7 +174,10 @@ class IpeImage(DaskImage):
     @property
     def ipe_metadata(self):
         if self._ipe_metadata is None:
-            self._ipe_metadata = get_ipe_metadata(self.interface.gbdx_connection, self.ipe_id, self.ipe_node_id)
+            try: 
+                self._ipe_metadata = get_ipe_metadata(self.interface.gbdx_connection, self.ipe_id, self.ipe_node_id)
+            except BadRequest:
+                raise 
         return self._ipe_metadata
 
     @property

--- a/gbdxtools/ipe/graph.py
+++ b/gbdxtools/ipe/graph.py
@@ -21,8 +21,8 @@ def register_ipe_graph(conn, ipe_graph):
 def fetch_metadata(conn, url):
     res = conn.get(url)
     res_json = res.json()
-    if res.status_code != 200 or res_json.has_key('error'):
-        raise BadRequest("Problem fetching image metadata: {}".format(res_json['error']))
+    if res.status_code != 200 or (res_json.has_key('error') or res_json.has_key('message')):
+        raise BadRequest("Problem fetching image metadata: {}".format(res_json.get('error', res_json['message'])))
     else:
         return res_json
 

--- a/gbdxtools/ipe/graph.py
+++ b/gbdxtools/ipe/graph.py
@@ -21,7 +21,7 @@ def register_ipe_graph(conn, ipe_graph):
 def fetch_metadata(conn, url):
     res = conn.get(url)
     res_json = res.json()
-    if res.status_code != 200 or (res_json.has_key('error') or res_json.has_key('message')):
+    if res.status_code != 200 or ('error' in res_json or 'message' in res_json):
         raise BadRequest("Problem fetching image metadata: {}".format(res_json.get('error', res_json['message'])))
     else:
         return res_json

--- a/tests/unit/cassettes/test_ipe_metadata.yaml
+++ b/tests/unit/cassettes/test_ipe_metadata.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://idahoapi.geobigdata.io/v1/metadata/idaho-virtual/no_id/toa_reflectance/image.json
+  response:
+    body: {string: !!python/unicode '{"message":"graph id no_id does not exist","exceptionType":"IPEServiceNotFoundException"}'}
+    headers:
+      access-control-allow-headers: ['x-requested-with, X-Auth-Token, Content-Type,
+          Authorization']
+      access-control-allow-methods: ['GET, OPTIONS, HEAD, PUT, POST, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-max-age: ['3600']
+      connection: [keep-alive]
+      content-length: ['89']
+      content-type: [application/json]
+      date: ['Mon, 26 Jun 2017 17:06:58 GMT']
+    status: {code: 404, message: Not Found}
+version: 1

--- a/tests/unit/test_ipe_image.py
+++ b/tests/unit/test_ipe_image.py
@@ -7,6 +7,8 @@ Unit tests for the gbdxtools.Idaho class
 
 from gbdxtools import Interface
 from gbdxtools import IdahoImage
+from gbdxtools.ipe.graph import get_ipe_metadata
+from gbdxtools.ipe.error import BadRequest
 from auth_mock import get_mock_gbdx_session
 import vcr
 from os.path import join, isfile, dirname, realpath
@@ -90,3 +92,11 @@ class IpeImageTest(unittest.TestCase):
         assert img.shape == (8, 4514, 8135)
         assert img._proj == 'EPSG:3857'
         assert isinstance(img.vrt, str)
+
+    @my_vcr.use_cassette('tests/unit/cassettes/test_ipe_metadata.yaml', filter_headers=['authorization'])
+    def test_ipe_metadata_error(self):
+        ipe_id = 'no_id'
+        try:
+            meta = get_ipe_metadata(self.gbdx.gbdx_connection, ipe_id)
+        except BadRequest as err:
+            pass


### PR DESCRIPTION
Addresses #129 and will raise an error when image metadata are not cleanly fetched. This doesn't attempt to resolve any actual errors with regard to why the metadata might be having issues being fetched. There's a known bug around race conditions with fetching metadata, but this should help us debug those by raising the error before we try to access any metadata.