### PR TITLE
allow 3 retries for metadata before raising errors

### DIFF
--- a/gbdxtools/ipe/error.py
+++ b/gbdxtools/ipe/error.py
@@ -12,3 +12,6 @@ class Unauthorized(Exception):
 
 class Forbidden(Exception):
     pass
+
+class MaxTries(Exception):
+    pass

--- a/gbdxtools/ipe/graph.py
+++ b/gbdxtools/ipe/graph.py
@@ -22,7 +22,7 @@ def fetch_metadata(conn, url):
     res = conn.get(url)
     res_json = res.json()
     if res.status_code != 200 or ('error' in res_json or 'message' in res_json):
-        raise BadRequest("Problem fetching image metadata: {}".format(res_json.get('error', res_json['message'])))
+        raise BadRequest("Problem fetching image metadata: {}".format(res.content))
     else:
         return res_json
 


### PR DESCRIPTION
As suggested by Nate Mac i've added 3 retries to metadata requests in attempt to get around a timing issue in writing graph metadata to s3. This PR will take a 1 second pause between 3 tries for he metadata before failing. 

Its a race issue thats preventing metadata from being fetched this should work around it.   