### PR TITLE
Base layer matching plots

### DIFF
--- a/gbdxtools/images/meta.py
+++ b/gbdxtools/images/meta.py
@@ -466,7 +466,8 @@ class PlotMixin(object):
         if "blm" in kwargs and not kwargs["blm"]:
             return rgb
         from gbdxtools.images.tms_image import TmsImage
-        tms = TmsImage(zoom=18, bbox=self.bounds, **kwargs)
+        bounds = self._reproject(box(*self.bounds), from_proj=self.proj, to_proj="EPSG:4326").bounds
+        tms = TmsImage(zoom=18, bbox=bounds, **kwargs)
         ref = np.rollaxis(tms.read(), 0, 3)
         out = np.dstack([histogram_match(rgb[:,:,idx], ref[:,:,idx].astype(np.double)/255.0) 
                         for idx in xrange(rgb.shape[-1])])

--- a/meta.yaml
+++ b/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - gbdx-auth ==0.2.4
     - jpeg ==8d
     - cachetools >=2.0.0 # py27
+    - rio-hist
 
   build:
     - setuptools
@@ -63,3 +64,4 @@ requirements:
     - vcrpy
     - jpeg ==8d
     - cachetools >=2.0.0
+    - rio-hist

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ configparser
 mercantile>=0.10.0
 scikit-image
 cachetools >= 2.0.0
+rio-hist

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -20,3 +20,4 @@ configparser
 mercantile>=0.10.0
 scikit-image
 cachetools >=2.0.0
+rio-hist


### PR DESCRIPTION
Adds TmsImage base layer matching by default when calling plot. Needs `rio-hist` to be installed and supports looking up the `MAPBOX-API-KEY` and/or being passed an access_token. Also can be turned off by passing `blm=false` to any calls to `plot`.