### PR TITLE
Optional rasterio

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,6 @@ install:
   - "%PYTHON%\\python.exe -m pip install GDAL-2.1.3-cp27-cp27m-win32.whl"
   - "appveyor DownloadFile https://github.com/DigitalGlobe/gbdxtools-windows-binaries/raw/master/Shapely-1.5.17-cp27-cp27m-win32.whl"
   - "%PYTHON%\\python.exe -m pip install Shapely-1.5.17-cp27-cp27m-win32.whl"
-  - "appveyor DownloadFile https://github.com/DigitalGlobe/gbdxtools-windows-binaries/raw/master/rasterio-1.0a5-cp27-cp27m-win32.whl"
-  - "%PYTHON%\\python.exe -m pip install rasterio-1.0a5-cp27-cp27m-win32.whl"
   - "appveyor DownloadFile https://github.com/DigitalGlobe/gbdxtools-windows-binaries/raw/master/pyproj-1.9.5.1-cp27-cp27m-win32.whl"
   - "%PYTHON%\\python.exe -m pip install pyproj-1.9.5.1-cp27-cp27m-win32.whl"
   - "%PYTHON%\\python.exe -m pip install matplotlib pytest"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = ['pycurl', 'pyproj', 'rasterio', 'rio_hist']
+MOCK_MODULES = ['pycurl', 'pyproj']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 #                'boto',
@@ -49,9 +49,6 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 #                'dask.array',
 #                'numpy',
 #                'numpy.linalg',
-#                'rasterio',
-#                'rasterio.io',
-#                'rasterio.transform',
 #                'skimage',
 #                'skimage.transform',
 #                'skimage.transform._geometric']

--- a/environment.yml
+++ b/environment.yml
@@ -216,8 +216,6 @@ dependencies:
 - !!python/unicode
   'pyyaml=3.12=py27_1'
 - !!python/unicode
-  'rasterio=0.36.0=py27_1'
-- !!python/unicode
   'readline=6.2=0'
 - !!python/unicode
   'requests=2.12.1=py27_0'

--- a/gbdxtools/ipe/interface.py
+++ b/gbdxtools/ipe/interface.py
@@ -16,12 +16,7 @@ try:
 except ImportError:
     from cachetools.func import lru_cache
 
-import rasterio
-try:
-    from rasterio import RasterioIOError
-except ImportError:
-    from rasterio.errors import RasterioIOError
-
+from skimage.io import imread
 import pycurl
 import numpy as np
 
@@ -70,11 +65,10 @@ def load_url(url, token, shape=(8, 256, 256)):
                     raise TypeError("Request for {} returned unexpected error code: {}".format(url, code))
                 temp.file.flush()
                 temp.close()
-                with rasterio.open(temp.name) as dataset:
-                    arr = dataset.read()
+                arr = np.rollaxis(imread(temp.name), 2, 0)
                 success = True
                 return arr
-            except (TypeError, RasterioIOError) as e:
+            except Exception as e:
                 print(e)
                 _curl.close()
                 del _curl_pool[thread_id]

--- a/gbdxtools/ipe/io.py
+++ b/gbdxtools/ipe/io.py
@@ -1,4 +1,9 @@
-import rasterio
+try:
+    import rasterio
+    has_rasterio = True
+except:
+    has_rasterio = False
+
 import numpy as np
 from dask.array import store
 
@@ -12,6 +17,7 @@ class rio_writer(object):
         self.dst.write(chunk, window=window)
 
 def to_geotiff(arr, path='./output.tif', proj=None, bands=None, **kwargs):
+    assert has_rasterio, "To create geotiff images please install rasterio" 
     if bands is not None:
         arr = arr[bands,...]
 

--- a/install_windows.md
+++ b/install_windows.md
@@ -26,13 +26,6 @@ curl -outf Shapely-1.5.17-cp27-cp27m-win32.whl https://github.com/DigitalGlobe/g
 pip install .\Shapely-1.5.17-cp27-cp27m-win32.whl
 ```
 
-Install rasterio:
-
-```
-curl -outf rasterio-1.0a5-cp27-cp27m-win32.whl https://github.com/DigitalGlobe/gbdxtools-windows-binaries/blob/master/rasterio-1.0a5-cp27-cp27m-win32.whl?raw=true
-pip install .\rasterio-1.0a5-cp27-cp27m-win32.whl
-```
-
 Install pyproj:
 
 ```

--- a/meta.yaml
+++ b/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - dask ==0.15.4
     - numpy
     - pycurl
-    - rasterio >=0.36.0
     - pyproj
     - requests-futures
     - configparser
@@ -50,7 +49,6 @@ requirements:
     - dask ==0.15.4
     - {{ pin_compatible('numpy', min_pin='1.9') }}
     - pycurl
-    - rasterio >=0.36.0
     - pyproj
     - requests-futures
     - configparser

--- a/meta.yaml
+++ b/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - gbdx-auth ==0.2.4
     - jpeg ==8d
     - cachetools >=2.0.0 # py27
+    - affine
 
   build:
     - setuptools
@@ -61,3 +62,4 @@ requirements:
     - vcrpy
     - jpeg ==8d
     - cachetools >=2.0.0
+    - affine

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ cloudpickle
 dask==0.15.4
 numpy
 pycurl
-rasterio>=0.36
 pyproj
 requests_futures
 configparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ configparser
 mercantile>=0.10.0
 scikit-image
 cachetools >= 2.0.0
+affine

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -19,3 +19,4 @@ configparser
 mercantile>=0.10.0
 scikit-image
 cachetools >=2.0.0
+affine

--- a/tests/unit/test_catalog_image.py
+++ b/tests/unit/test_catalog_image.py
@@ -10,7 +10,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 
 # How to use the mock_gbdx_session and vcr to create unit tests:
 # 1. Add a new test that is dependent upon actually hitting GBDX APIs.

--- a/tests/unit/test_dem_image.py
+++ b/tests/unit/test_dem_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 try:

--- a/tests/unit/test_geoeye_image.py
+++ b/tests/unit/test_geoeye_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_ikonos_image.py
+++ b/tests/unit/test_ikonos_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_ipe_image.py
+++ b/tests/unit/test_ipe_image.py
@@ -152,14 +152,3 @@ class IpeImageTest(unittest.TestCase):
         aoi.ortho = read_mock
         ortho = aoi.warp()
         assert isinstance(ortho, DaskImage)
-
-    #@my_vcr.use_cassette('tests/unit/cassettes/test_ipe_image_geotiff.yaml', filter_headers=['authorization'])
-    #def test_ipe_image_geotiff(self):
-    #    idahoid = '179269b9-fdb3-49d8-bb62-d15de54ad15d'
-    #    img = self.gbdx.idaho_image(idahoid, bbox=[-110.85299491882326,32.167148499672855,-110.84870338439943,32.170236308395644])
-    #    tif = img.geotiff(path='/tmp/tmp.tif', dtype='uint16')
-    #    with rasterio.open(tif) as src:
-    #        assert [round(x, 3) for x in list(src.bounds)] == [-110.853, 32.167, -110.849, 32.17]
-    #        assert src.meta['width'] == 239
-    #        assert src.meta['height'] == 172
-    #        assert src.meta['dtype'] == 'uint16'

--- a/tests/unit/test_landsat_image.py
+++ b/tests/unit/test_landsat_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_quickbird_image.py
+++ b/tests/unit/test_quickbird_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_s3_image.py
+++ b/tests/unit/test_s3_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_sentinel2_image.py
+++ b/tests/unit/test_sentinel2_image.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 import dask.array as da
 
 def force(r1, r2):

--- a/tests/unit/test_worldview.py
+++ b/tests/unit/test_worldview.py
@@ -12,7 +12,6 @@ import vcr
 from os.path import join, isfile, dirname, realpath
 import tempfile
 import unittest
-import rasterio
 
 try:
     from urlparse import urlparse


### PR DESCRIPTION
This PR makes rasterio an optional dependency and only used for creating geotiffs. the motivation here is that we've been running users and ourselves having trouble installing rasterio (and its deps). Removing it will make gbdxtools much lighter, but will require users to install rasterio separately, where they can sift through the installation independently. 