### PR TITLE
Cull graphs

### DIFF
--- a/gbdxtools/images/meta.py
+++ b/gbdxtools/images/meta.py
@@ -122,6 +122,8 @@ class DaskImage(da.Array):
                     except AttributeError:
                         # this means result was an object with __slots__
                         pass
+                    dsk, _ = optimize.cull(copy.dask, copy.__dask_keys__())
+                    copy.dask = dsk
                     return copy
                 return result
             return wrapped


### PR DESCRIPTION
This PR implements dask-graph optimization via `cull` after graph manipulation (creation of images w/ bboxes, aoi's on images). This makes it so that image graphs carry only the keys needed to do compute across the image, making the graph lighter and easier to inspect as well.