### PR TITLE
Retry on 401 response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 /venv
 /.idea/
 chip.tif
+.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 /test-reports
 /venv
 /.idea/
+chip.tif

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -55,7 +55,8 @@ class _Auth(object):
                     # remove hooks so it doesn't get into infinite loop
                     r.request.hooks = None
                     # expire the token
-                    gbdx_auth.expire_token(token_to_expire=self.gbdx_connection.token)
+                    gbdx_auth.expire_token(token_to_expire=self.gbdx_connection.token,
+                                           config_file=kwargs.get('config_file'))
                     # re-init the session
                     self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
                     # make original request, triggers new token request first

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -20,7 +20,7 @@ class _Auth(object):
     gbdx_connection = None
     root_url = 'https://geobigdata.io'
 
-    def __init__(self, **kw):
+    def __init__(self, **kwargs):
         self.logger = logging.getLogger('gbdxtools')
         self.logger.setLevel(logging.ERROR)
         self.console_handler = logging.StreamHandler()
@@ -30,26 +30,26 @@ class _Auth(object):
         self.logger.addHandler(self.console_handler)
         self.logger.info('Logger initialized')
 
-        if 'host' in kw:
-            self.root_url = 'https://%s' % kw.get('host')
+        if 'host' in kwargs:
+            self.root_url = 'https://%s' % kwargs.get('host')
         try:
-            if (kw.get('username') and kw.get('password') and
-                    kw.get('client_id') and kw.get('client_secret')):
-                self.gbdx_connection = gbdx_auth.session_from_kwargs(**kw)
-            elif kw.get('gbdx_connection'):
-                self.gbdx_connection = kw.get('gbdx_connection')
+            if (kwargs.get('username') and kwargs.get('password') and
+                    kwargs.get('client_id') and kwargs.get('client_secret')):
+                self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
+            elif kwargs.get('gbdx_connection'):
+                self.gbdx_connection = kwargs.get('gbdx_connection')
             elif self.gbdx_connection is None:
                 # This will throw an exception if your .ini file is not set properly
-                self.gbdx_connection = gbdx_auth.get_session(kw.get('config_file'))
+                self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
         except Exception as err:
             print(err)
 
-        def expire_token(r, *args, **kwargs):
+        def expire_token(r, *args, **kw):
             """
             Requests a new token if 401, retries request, mainly for auth v2 migration
             :param r:
             :param args:
-            :param kwargs:
+            :param kw:
             :return:
             """
             if r.status_code == 401:
@@ -58,9 +58,9 @@ class _Auth(object):
                     r.request.hooks = None
                     # expire the token
                     gbdx_auth.expire_token(token_to_expire=self.gbdx_connection.token,
-                                           config_file=kw.get('config_file'))
+                                           config_file=kwargs.get('config_file'))
                     # re-init the session
-                    self.gbdx_connection = gbdx_auth.get_session(kw.get('config_file'))
+                    self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
                     # make original request, triggers new token request first
                     return self.gbdx_connection.request(method=r.request.method, url=r.request.url)
 

--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -8,17 +8,19 @@ from gbdxtools.ipe.graph import VIRTUAL_IPE_URL
 
 auth = None
 
+
 def Auth(**kwargs):
     global auth
     if auth is None or len(kwargs) > 0:
         auth = _Auth(**kwargs)
     return auth
 
+
 class _Auth(object):
     gbdx_connection = None
     root_url = 'https://geobigdata.io'
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kw):
         self.logger = logging.getLogger('gbdxtools')
         self.logger.setLevel(logging.ERROR)
         self.console_handler = logging.StreamHandler()
@@ -28,17 +30,17 @@ class _Auth(object):
         self.logger.addHandler(self.console_handler)
         self.logger.info('Logger initialized')
 
-        if 'host' in kwargs:
-            self.root_url = 'https://%s' % kwargs.get('host')
+        if 'host' in kw:
+            self.root_url = 'https://%s' % kw.get('host')
         try:
-            if (kwargs.get('username') and kwargs.get('password') and
-                    kwargs.get('client_id') and kwargs.get('client_secret')):
-                self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
-            elif kwargs.get('gbdx_connection'):
-                self.gbdx_connection = kwargs.get('gbdx_connection')
+            if (kw.get('username') and kw.get('password') and
+                    kw.get('client_id') and kw.get('client_secret')):
+                self.gbdx_connection = gbdx_auth.session_from_kwargs(**kw)
+            elif kw.get('gbdx_connection'):
+                self.gbdx_connection = kw.get('gbdx_connection')
             elif self.gbdx_connection is None:
                 # This will throw an exception if your .ini file is not set properly
-                self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
+                self.gbdx_connection = gbdx_auth.get_session(kw.get('config_file'))
         except Exception as err:
             print(err)
 
@@ -56,9 +58,9 @@ class _Auth(object):
                     r.request.hooks = None
                     # expire the token
                     gbdx_auth.expire_token(token_to_expire=self.gbdx_connection.token,
-                                           config_file=kwargs.get('config_file'))
+                                           config_file=kw.get('config_file'))
                     # re-init the session
-                    self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
+                    self.gbdx_connection = gbdx_auth.get_session(kw.get('config_file'))
                     # make original request, triggers new token request first
                     return self.gbdx_connection.request(method=r.request.method, url=r.request.url)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six>=1.10.0
 future>=0.15.2
 requests>=2.12.1
 boto3
-git+https://TDG-deploy-read-only:d9d60a5d8137f2d946474aa33458eeff1527a4ec@github.com/TDG-Platform/gbdx-auth@update_gbdx_tools
+gbdx-auth==0.2.4
 pytest
 pytest-runner
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six>=1.10.0
 future>=0.15.2
 requests>=2.12.1
 boto3
-gbdx-auth==0.2.4
+gbdx-auth==0.2.6
 pytest
 pytest-runner
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six>=1.10.0
 future>=0.15.2
 requests>=2.12.1
 boto3
-gbdx-auth==0.2.4
+git+https://TDG-deploy-read-only:d9d60a5d8137f2d946474aa33458eeff1527a4ec@github.com/TDG-Platform/gbdx-auth@update_gbdx_tools
 pytest
 pytest-runner
 vcrpy

--- a/tests/unit/cassettes/test_auth_401_retry.yaml
+++ b/tests/unit/cassettes/test_auth_401_retry.yaml
@@ -1,0 +1,132 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://geobigdata.io/workflows/v1/tasks/AOP_Strip_Processor
+  response:
+    body: {string: !!python/unicode '{"status": "401 Unauthorized", "message": "Authentication
+        Failed."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['67']
+      content-type: [text/html; charset=UTF-8]
+      date: ['Fri, 16 Feb 2018 17:48:29 GMT']
+      server: [nginx/1.12.1]
+      via: [kong/0.10.3]
+      x-kong-proxy-latency: ['0']
+      x-kong-upstream-latency: ['131']
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: !!python/unicode 'client_secret=dwada&grant_type=refresh_token&refresh_token=dwadwaN&client_id=3%40%3Bc%3FU'
+    headers:
+      Accept: [!!python/unicode 'application/json']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['316']
+      Content-Type: [!!python/unicode 'application/x-www-form-urlencoded;charset=UTF-8']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://geobigdata.io/auth/v1/oauth/token/
+  response:
+    body: {string: !!python/unicode '{"access_token": "dummyToken",
+        "scope": "read write", "token_type": "Bearer", "expires_in": 604800, "refresh_token":
+        "dummyToken"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['486']
+      content-type: [application/json]
+      date: ['Fri, 16 Feb 2018 17:48:52 GMT']
+      p3p: [CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"]
+      server: [nginx/1.12.1]
+      via: [kong/0.10.3]
+      x-frame-options: [SAMEORIGIN]
+      x-kong-proxy-latency: ['0']
+      x-kong-upstream-latency: ['6']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://geobigdata.io/workflows/v1/tasks/AOP_Strip_Processor
+  response:
+    body: {string: !!python/unicode '{"containerDescriptors": [{"command": "/bin/bash
+        /dg/aws/apps/AOP-Processing/aws/gbdx/aop_strip_processor_task/aop_strip_processor_task_runner.sh",
+        "type": "DOCKER", "properties": {"image": "test", "domain": "raid"}}],
+        "description": "Processes a 1B strip using the AOP processing stack.", "inputPortDescriptors":
+        [{"required": true, "type": "directory", "description": "S3 location of 1B
+        input data", "name": "data"}, {"required": false, "type": "directory", "description":
+        "S3 location of Bundle Block Adjustment results", "name": "bba"}, {"required":
+        false, "type": "string", "description": "Enable/disable AComp. Choices are
+        ''true'' or ''false''. Default is ''true''.", "name": "enable_acomp"}, {"required":
+        false, "type": "string", "description": "Enable/disable pan sharpening. Choices
+        are ''true'' or ''false''. Default is ''true''.", "name": "enable_pansharpen"},
+        {"required": false, "type": "string", "description": "Enable/disable dynamic
+        range adjustment. Choices are ''true'' or ''false''. Default is ''true''.",
+        "name": "enable_dra"}, {"required": false, "type": "string", "description":
+        "Enable/disable output tiling. Choices are ''true'' or ''false''. Default
+        is ''false''. If ''true'', the ''ortho_tiling_scheme'' input must be set.",
+        "name": "enable_tiling"}, {"required": false, "type": "string", "description":
+        "Bands to process. Choices are ''PAN+MS'', ''PAN'', ''MS'', ''Auto''. Default
+        is ''Auto'', which searches for band IDs in IMD files.", "name": "bands"},
+        {"required": false, "type": "string", "description": "Comma-separated list
+        of numeric strip parts to process. Default is to process all strip parts.",
+        "name": "parts"}, {"required": false, "type": "string", "description": "Ortho
+        EPSG projection. String ''UTM'' is also allowed. Specify along with ortho_pixel_size.
+        Overridden by ortho_tiling_scheme if specified. Default is ''EPSG:4326''.",
+        "name": "ortho_epsg"}, {"required": false, "type": "string", "description":
+        "Ortho pixel size in meters. Specify along with ortho_epsg. Overridden by
+        ortho_tiling_scheme if specified. Default is ''Auto'', which uses the pixel
+        size of the input data.", "name": "ortho_pixel_size"}, {"required": false,
+        "type": "string", "description": "Ortho tiling scheme and zoom level, e.g.
+        ''DGHalfMeter:18''. Overrides ortho_epsg and ortho_pixel_size.", "name": "ortho_tiling_scheme"},
+        {"required": false, "type": "string", "description": "S3 URL of DEM for orthorectification.
+        Default is s3://dgdem/current.txt, which is a periodic snapshot of the DEMs
+        used in the factory.", "name": "ortho_dem_specifier"}, {"required": false,
+        "type": "string", "description": "Ortho pixel interpolation type. Options
+        are ''Nearest'', ''Bilinear'', ''Cubic''. Default is ''Cubic''.", "name":
+        "ortho_interpolation_type"}, {"required": false, "type": "string", "description":
+        "Dynamic range adjustment mode. Options are ''IntensityAdjust'', ''BaseLayerMatch''.
+        Default is ''IntensityAdjust''. ''BaseLayerMatch'' is currently only compatible
+        with EPSG:4326.", "name": "dra_mode"}, {"required": false, "type": "string",
+        "description": "Dynamic range adjustment low cutoff percentage. Range is from
+        0 to 100. Default is 0.5. Only used for ''IntensityAdjust'' mode.", "name":
+        "dra_low_cutoff"}, {"required": false, "type": "string", "description": "Dynamic
+        range adjustment high cutoff percentage. Range is from 0 to 100. Default is
+        99.95. Only used for ''IntensityAdjust'' mode.", "name": "dra_high_cutoff"},
+        {"required": false, "type": "string", "description": "Dynamic range adjustment
+        gamma value. Default is 1.25. Only used for ''IntensityAdjust'' mode.", "name":
+        "dra_gamma"}, {"required": false, "type": "string", "description": "Dynamic
+        range adjustment output bit depth. Choices are 8 or 16. Default is 8. Only
+        used for ''IntensityAdjust'' mode.", "name": "dra_bit_depth"}, {"required":
+        false, "type": "string", "description": "S3 prefix of base layer for DRA BaseLayerMatch
+        mode. Default is s3://dg-baselayer/v2/. Base layer should be tiled to DG tiling
+        scheme level 9.", "name": "dra_baselayer_prefix"}, {"required": false, "type":
+        "string", "description": "Zoom level (i.e. size) of output tiles if tiling
+        is enabled. Default is 12.", "name": "tiling_zoom_level"}], "version": "0.0.4",
+        "outputPortDescriptors": [{"required": true, "type": "directory", "description":
+        "The output data directory", "name": "data"}, {"required": true, "type": "directory",
+        "description": "The output log directory", "name": "log"}], "properties":
+        {"isPublic": true, "canPersist": true, "timeout": 36000}, "name": "AOP_Strip_Processor"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['4509']
+      content-type: [application/json]
+      date: ['Fri, 16 Feb 2018 17:48:31 GMT']
+      server: [nginx/1.12.1]
+      via: [kong/0.10.3]
+      x-kong-proxy-latency: ['0']
+      x-kong-upstream-latency: ['955']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -33,7 +33,7 @@ user_password = your_password
 """
 
 # create temp gbdx-config file
-temp = tempfile.NamedTemporaryFile(dir=os.getcwd(), suffix=".ini", mode="w+t", delete=False)
+temp = tempfile.NamedTemporaryFile(prefix="gbdx-auth", suffix=".ini", mode="w+t", delete=False)
 # write the data
 temp.write(data)
 temp.seek(0)

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -33,7 +33,7 @@ user_password = your_password
 """
 
 # create temp gbdx-config file
-temp = tempfile.NamedTemporaryFile(dir=os.getcwd(), suffix=".ini", mode="w+t")
+temp = tempfile.NamedTemporaryFile(dir=os.getcwd(), suffix=".ini", mode="w+t", delete=False)
 # write the data
 temp.write(data)
 temp.seek(0)

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -32,7 +32,7 @@ user_password = your_password
 """
 
 # create temp gbdx-config file
-temp = tempfile.NamedTemporaryFile(dir="/tmp", suffix=".ini", mode="w+t")
+temp = tempfile.NamedTemporaryFile(suffix=".ini", mode="w+t")
 # write the data
 temp.write(data)
 temp.seek(0)

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -1,0 +1,39 @@
+from gbdxtools import Interface
+from auth_mock import get_mock_gbdx_session
+import vcr
+import urllib
+import unittest
+
+"""
+How to use the mock_gbdx_session and vcr to create unit tests:
+1. Add a new test that is dependent upon actually hitting GBDX APIs.
+2. Decorate the test with @vcr appropriately, supply a yaml file path to gbdxtools/tests/unit/cassettes
+    note: a yaml file will be created after the test is run
+
+3. Replace "dummytoken" with a real gbdx token after running test successfully
+4. Run the tests (existing test shouldn't be affected by use of a real token).  This will record a "cassette".
+5. Replace the real gbdx token with "dummytoken" again
+6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
+"""
+
+
+class TestAuthRetry(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        token = {"token_type": "Bearer", "refresh_token": "dummyToken", "access_token": "dummytoken",
+                 "scope": ["read", "write"],
+                 "expires_in": 604800, "expires_at": 1519399815.364629}
+
+        mock_gbdx_session = get_mock_gbdx_session(token=token)
+        cls.gbdx = Interface(gbdx_connection=mock_gbdx_session)
+
+    @vcr.use_cassette('tests/unit/cassettes/test_auth_401_retry.yaml', filter_headers=['authorization'],
+                      record_mode='once', decode_compressed_response=True)
+    def test_auth_401_retry(self):
+        """
+        We want to test that on 401, a new token is fetched and the original request is retried
+        This is for seamless migration to auth v2
+        :return:
+        """
+        # if this test passes it means the 401 retry worked, see the cassette for details
+        self.gbdx.Task("AOP_Strip_Processor")

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -32,7 +32,7 @@ user_password = your_password
 """
 
 # create temp gbdx-config file
-temp = tempfile.NamedTemporaryFile(suffix=".ini")
+temp = tempfile.NamedTemporaryFile(dir="/tmp", suffix=".ini", mode="w+t")
 # write the data
 temp.write(data)
 temp.seek(0)

--- a/tests/unit/test_401_retry.py
+++ b/tests/unit/test_401_retry.py
@@ -1,5 +1,6 @@
 from gbdxtools import Interface
 from auth_mock import get_mock_gbdx_session
+import os
 import vcr
 import tempfile
 import unittest
@@ -32,7 +33,7 @@ user_password = your_password
 """
 
 # create temp gbdx-config file
-temp = tempfile.NamedTemporaryFile(suffix=".ini", mode="w+t")
+temp = tempfile.NamedTemporaryFile(dir=os.getcwd(), suffix=".ini", mode="w+t")
 # write the data
 temp.write(data)
 temp.seek(0)


### PR DESCRIPTION
For auth v2 migrations we want to retry a request that resulted in 401. This PR expires the token and retries the request, which triggers a new token generation from the OAuth library. I still need to push gbdx-auth to pypi with version 0.2.7. 

Also here is the PR for gbdx-auth 
https://github.com/TDG-Platform/gbdx-auth/pull/17

**Will update this PR when I get permissions to pypi, for review only now. The build won't pass till I update gbdx-auth in pypi**