### PR TITLE
Index methods template

### DIFF
--- a/gbdxtools/images/meta.py
+++ b/gbdxtools/images/meta.py
@@ -8,16 +8,11 @@ import math
 
 from gbdxtools.ipe.io import to_geotiff
 from gbdxtools.ipe.util import RatPolyTransform, AffineTransform, pad_safe_positive, pad_safe_negative, IPE_TO_DTYPE, preview
+from gbdxtools.images.mixins import PlotMixin, BandMethodsTemplate
 
 from shapely import ops, wkt
 from shapely.geometry import box, shape, mapping, asShape
 from shapely.geometry.base import BaseGeometry
-try:
-    from rio_hist.match import histogram_match
-    has_rio = True
-except ImportError:
-    has_rio = False
-import mercantile
 
 import skimage.transform as tf
 
@@ -30,12 +25,6 @@ from dask.base import is_dask_collection
 import numpy as np
 
 from affine import Affine
-
-try:
-    from matplotlib import pyplot as plt
-    has_pyplot = True
-except:
-    has_pyplot = False
 
 try:
     xrange
@@ -131,90 +120,8 @@ class DaskImage(da.Array):
             for i in xrange(count):
                 yield self.randwindow(window_shape)
 
-# Mixin class that defines plotting methods and rgb/ndvi methods
-# used as a mixin to provide access to the plot method on
-# GeoDaskWrapper images and ipe images
-class PlotMixin(object):
-    @property
-    def _rgb_bands(self):
-        return [4, 2, 1]
 
-    @property
-    def _ndvi_bands(self):
-        return [6, 4]
-
-    def base_layer_match(self, blm=False, **kwargs):
-        rgb = self.rgb(**kwargs)
-        if not blm:
-            return rgb
-        from gbdxtools.images.tms_image import TmsImage
-        bounds = self._reproject(box(*self.bounds), from_proj=self.proj, to_proj="EPSG:4326").bounds
-        tms = TmsImage(zoom=self._calc_tms_zoom(self.affine[0]), bbox=bounds, **kwargs)
-        ref = np.rollaxis(tms.read(), 0, 3)
-        out = np.dstack([histogram_match(rgb[:,:,idx], ref[:,:,idx].astype(np.double)/255.0)
-                        for idx in xrange(rgb.shape[-1])])
-        return out
-
-    def rgb(self, **kwargs):
-        data = self._read(self[kwargs.get("bands", self._rgb_bands),...], **kwargs)
-        data = np.rollaxis(data.astype(np.float32), 0, 3)
-        lims = np.percentile(data, kwargs.get("stretch", [2, 98]), axis=(0, 1))
-        for x in xrange(len(data[0,0,:])):
-            top = lims[:,x][1]
-            bottom = lims[:,x][0]
-            data[:,:,x] = (data[:,:,x] - bottom) / float(top - bottom)
-        return np.clip(data, 0, 1)
-
-    def ndvi(self, **kwargs):
-        data = self._read(self[self._ndvi_bands,...]).astype(np.float32)
-        return (data[0,:,:] - data[1,:,:]) / (data[0,:,:] + data[1,:,:])
-
-    def plot(self, spec="rgb", **kwargs):
-        if self.shape[0] == 1 or ("bands" in kwargs and len(kwargs["bands"]) == 1):
-            if "cmap" in kwargs:
-                cmap = kwargs["cmap"]
-                del kwargs["cmap"]
-            else:
-                cmap = "Greys_r"
-            self._plot(tfm=self._single_band, cmap=cmap, **kwargs)
-        else:
-            if spec == "rgb" and self._has_token(**kwargs):
-                self._plot(tfm=self.base_layer_match, **kwargs)
-            else:
-                self._plot(tfm=getattr(self, spec), **kwargs)
-
-    def _has_token(self, **kwargs):
-        if "access_token" in kwargs or "MAPBOX_API_KEY" in os.environ:
-            return True
-        else:
-            return False
-
-    def _plot(self, tfm=lambda x: x, **kwargs):
-        assert has_pyplot, "To plot images please install matplotlib"
-        assert self.shape[1] and self.shape[-1], "No data to plot, dimensions are invalid {}".format(str(self.shape))
-
-        f, ax1 = plt.subplots(1, figsize=(kwargs.get("w", 10), kwargs.get("h", 10)))
-        ax1.axis('off')
-        plt.imshow(tfm(**kwargs), interpolation='nearest', cmap=kwargs.get("cmap", None))
-        plt.show(block=False)
-
-    def _read(self, data, **kwargs):
-        if hasattr(data, 'read'):
-            return data.read(**kwargs)
-        else:
-            return data.compute(get=threaded_get)
-
-    def _single_band(self, **kwargs):
-        return self._read(self[0,:,:], **kwargs)
-
-    def _calc_tms_zoom(self, scale):
-        for z in range(15,20):
-            b = mercantile.bounds(0,0,z)
-            if scale > math.sqrt((b.north - b.south)*(b.east - b.west) / (256*256)):
-                return z
-
-
-class GeoDaskImage(DaskImage, Container, PlotMixin):
+class GeoDaskImage(DaskImage, Container, PlotMixin, BandMethodsTemplate):
     _default_proj = "EPSG:4326"
 
     def map_blocks(self, *args, **kwargs):

--- a/gbdxtools/images/mixins/__init__.py
+++ b/gbdxtools/images/mixins/__init__.py
@@ -1,0 +1,1 @@
+from gbdxtools.images.mixins.geo import PlotMixin, BandMethodsTemplate

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -91,12 +91,12 @@ class PlotMixin(object):
 class BandMethodsTemplate(object):
     @property
     def _rgb_bands(self):
-        raise NotImplementedError
+        raise NotImplementedError("RGB bands undefined for image type {}".format(self.__class__.__name__))
 
     @property
     def _ndvi_bands(self):
-        raise NotImplementedError
+        raise NotImplementedError("NDVI bands undefined for image type {}".format(self.__class__.__name__))
 
     @property
     def _ndwi_bands(self):
-        raise NotImplementedError
+        raise NotImplementedError("NDWI bands undefined for image type {}".format(self.__class__.__name__))

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -1,0 +1,102 @@
+import os
+try:
+    from rio_hist.match import histogram_match
+    has_rio = True
+except ImportError:
+    has_rio = False
+
+import mercantile
+from shapely.geometry import box, shape, mapping, asShape
+
+import numpy as np
+try:
+    from matplotlib import pyplot as plt
+    has_pyplot = True
+except:
+    has_pyplot = False
+
+
+class PlotMixin(object):
+    def base_layer_match(self, blm=False, **kwargs):
+        rgb = self.rgb(**kwargs)
+        if not blm:
+            return rgb
+        from gbdxtools.images.tms_image import TmsImage
+        bounds = self._reproject(box(*self.bounds), from_proj=self.proj, to_proj="EPSG:4326").bounds
+        tms = TmsImage(zoom=self._calc_tms_zoom(self.affine[0]), bbox=bounds, **kwargs)
+        ref = np.rollaxis(tms.read(), 0, 3)
+        out = np.dstack([histogram_match(rgb[:,:,idx], ref[:,:,idx].astype(np.double)/255.0)
+                        for idx in range(rgb.shape[-1])])
+        return out
+
+    def rgb(self, **kwargs):
+        data = self._read(self[kwargs.get("bands", self._rgb_bands),...], **kwargs)
+        data = np.rollaxis(data.astype(np.float32), 0, 3)
+        lims = np.percentile(data, kwargs.get("stretch", [2, 98]), axis=(0, 1))
+        for x in range(len(data[0,0,:])):
+            top = lims[:,x][1]
+            bottom = lims[:,x][0]
+            data[:,:,x] = (data[:,:,x] - bottom) / float(top - bottom)
+        return np.clip(data, 0, 1)
+
+    def ndvi(self, **kwargs):
+        data = self._read(self[self._ndvi_bands,...]).astype(np.float32)
+        return (data[0,:,:] - data[1,:,:]) / (data[0,:,:] + data[1,:,:])
+
+    def plot(self, spec="rgb", **kwargs):
+        if self.shape[0] == 1 or ("bands" in kwargs and len(kwargs["bands"]) == 1):
+            if "cmap" in kwargs:
+                cmap = kwargs["cmap"]
+                del kwargs["cmap"]
+            else:
+                cmap = "Greys_r"
+            self._plot(tfm=self._single_band, cmap=cmap, **kwargs)
+        else:
+            if spec == "rgb" and self._has_token(**kwargs):
+                self._plot(tfm=self.base_layer_match, **kwargs)
+            else:
+                self._plot(tfm=getattr(self, spec), **kwargs)
+
+    def _has_token(self, **kwargs):
+        if "access_token" in kwargs or "MAPBOX_API_KEY" in os.environ:
+            return True
+        else:
+            return False
+
+    def _plot(self, tfm=lambda x: x, **kwargs):
+        assert has_pyplot, "To plot images please install matplotlib"
+        assert self.shape[1] and self.shape[-1], "No data to plot, dimensions are invalid {}".format(str(self.shape))
+
+        f, ax1 = plt.subplots(1, figsize=(kwargs.get("w", 10), kwargs.get("h", 10)))
+        ax1.axis('off')
+        plt.imshow(tfm(**kwargs), interpolation='nearest', cmap=kwargs.get("cmap", None))
+        plt.show(block=False)
+
+    def _read(self, data, **kwargs):
+        if hasattr(data, 'read'):
+            return data.read(**kwargs)
+        else:
+            return data.compute(get=threaded_get)
+
+    def _single_band(self, **kwargs):
+        return self._read(self[0,:,:], **kwargs)
+
+    def _calc_tms_zoom(self, scale):
+        for z in range(15,20):
+            b = mercantile.bounds(0,0,z)
+            if scale > math.sqrt((b.north - b.south)*(b.east - b.west) / (256*256)):
+                return z
+
+
+class BandMethodsTemplate(object):
+    @property
+    def _rgb_bands(self):
+        raise NotImplementedError
+
+    @property
+    def _ndvi_bands(self):
+        raise NotImplementedError
+
+    @property
+    def _ndwi_bands(self):
+        raise NotImplementedError

--- a/gbdxtools/images/worldview.py
+++ b/gbdxtools/images/worldview.py
@@ -47,11 +47,18 @@ class WorldViewImage(RDABaseImage):
     def _build_graph(cls, cat_id, band_type="MS", proj="EPSG:4326", gsd=None, acomp=False, **kwargs):
         bands = band_types[band_type]
         gsd = gsd if not None else ""
-        correction = "ACOMP" if acomp else kwargs.get("correctionType", "TOAREFLECTANCE") 
+        correction = "ACOMP" if acomp else kwargs.get("correctionType", "TOAREFLECTANCE")
         graph = ipe.Format(ipe.DigitalGlobeStrip(catId=cat_id, CRS=proj, GSD=gsd, correctionType=correction, bands=bands, fallbackToTOA=True), dataType="4")
         #raise AcompUnavailable("Cannot apply acomp to this image, data unavailable in bucket: {}".format(_bucket))
         return graph
 
+    @property
+    def _rgb_bands(self):
+        return [4, 2, 1]
+
+    @property
+    def _ndvi_bands(self):
+        return [6, 4]
 
 class WV03_SWIR(WorldViewImage):
     @staticmethod
@@ -66,6 +73,14 @@ class WV03_SWIR(WorldViewImage):
         correction = "ACOMP" if acomp else kwargs.get("correctionType", "TOAREFLECTANCE")
         graph = ipe.Format(ipe.DigitalGlobeStrip(catId=cat_id, CRS=proj, GSD=gsd, correctionType=correction, bands=bands, fallbackToTOA=True), dataType="4")
         return graph
+
+    @property
+    def _rgb_bands(self):
+        raise NotImplementedError("RGB bands not available in SWIR spectrum")
+
+    @property
+    def _ndvi_bands(self):
+        raise NotImplementedError("NDVI bands not available in SWIR spectrum")
 
 
 class WV03_VNIR(WorldViewImage):

--- a/tests/unit/test_ipe_image.py
+++ b/tests/unit/test_ipe_image.py
@@ -67,7 +67,7 @@ class IpeImageTest(unittest.TestCase):
     @my_vcr.use_cassette('tests/unit/cassettes/test_ipe_image_init_with_aoi2.yaml', filter_headers=['authorization'])
     def test_ipe_image_with_aoi(self):
         idahoid = '09d5acaf-12d4-4c67-adbb-cda26cbd2187'
-        img = self.gbdx.idaho_image(idahoid, bbox=[-85.79713384556237, 10.859474119490333, 
+        img = self.gbdx.idaho_image(idahoid, bbox=[-85.79713384556237, 10.859474119490333,
                                                    -85.79366000529654, 10.86341028280643], bucket='idaho-images')
         assert img.shape == (8, 292, 258)
         assert img.proj == 'EPSG:4326'
@@ -75,7 +75,7 @@ class IpeImageTest(unittest.TestCase):
     @my_vcr.use_cassette('tests/unit/cassettes/test_ipe_image_with_proj.yaml', filter_headers=['authorization'])
     def test_ipe_image_with_proj(self):
         idahoid = '09d5acaf-12d4-4c67-adbb-cda26cbd2187'
-        img = self.gbdx.idaho_image(idahoid, bbox=[-85.79713384556237, 10.859474119490333, 
+        img = self.gbdx.idaho_image(idahoid, bbox=[-85.79713384556237, 10.859474119490333,
                                                    -85.79366000529654, 10.86341028280643], proj='EPSG:3857', bucket='idaho-images')
         assert img.shape == (8, 298, 258)
         assert img.proj == 'EPSG:3857'
@@ -104,7 +104,8 @@ class IpeImageTest(unittest.TestCase):
         idahoid = '09d5acaf-12d4-4c67-adbb-cda26cbd2187'
         img = self.gbdx.idaho_image(idahoid, product="1b", bbox=[-85.79713384556237, 10.859474119490333, -85.79366000529654, 10.86341028280643], bucket='idaho-images')
         assert isinstance(img.ipe_metadata, dict)
-        assert img._ndvi_bands == [6, 4]
+        with self.assertRaises(NotImplementedError):
+            img._ndvi_bands
         assert img.shape == (8, 292, 258)
         assert isinstance(img, da.Array)
 
@@ -125,7 +126,7 @@ class IpeImageTest(unittest.TestCase):
     #    aoi.rgb = read_mock
     #    rgb = aoi.rgb()
     #    assert isinstance(rgb, np.ndarray)
-    
+
     @my_vcr.use_cassette('tests/unit/cassettes/test_ipe_image_ortho.yaml', filter_headers=['authorization'])
     def test_ipe_image_ortho(self):
         idahoid = '09d5acaf-12d4-4c67-adbb-cda26cbd2187'


### PR DESCRIPTION
Breaking out our mixins into module. PlotMixin is meant to work with predefined index methods laid out by the template mixin. This means that any image that doesn't define those properties for itself will at the least raise an informative error, which for the time being seems like a reasonable solution to the problem of  failing randomly.  A better, future solution ought to figure out how to instantiate image classes without inheriting methods that they don't define or aren't applicable. 