### PR TITLE
Add generation of slippy map thumbnails, fix feature popup tables

### DIFF
--- a/gbdxtools/vectors.py
+++ b/gbdxtools/vectors.py
@@ -307,15 +307,17 @@ class Vectors(object):
         map_id = "map_{}".format(str(int(time.time())))
         display(HTML(Template('''
            <div id="$map_id"/>
-           <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.css' rel='stylesheet' />
+           <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
            <style>body{margin:0;padding:0;}#$map_id{position:relative;top:0;bottom:0;width:100%;height:400px;}</style>
-           <style>.mapboxgl-popup-content table tr{border: 1px solid #efefef;} .mapboxgl-popup-content table, td, tr{border: none;}</style>
+           <style>.mapboxgl-popup-content table tr{border: 1px solid #efefef;} .mapboxgl-popup-content table, td, tr{border: none;}
+           .mapboxgl-popup-content table {width: 100%; table-layout: fixed; text-align: left;} .mapboxgl-popup-content td:first-of-type{width: 33%;}
+           .mapboxgl-popup-content {width: 400px !important;} .mapboxgl-popup-content td:last-of-type{overflow-x: scroll;}<style>
         ''').substitute({"map_id": map_id})))
 
         js = Template("""
             require.config({
               paths: {
-                  mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl',
+                  mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl',
               }
             });
 
@@ -340,6 +342,7 @@ class Vectors(object):
                     style: 'mapbox://styles/mapbox/satellite-v9',
                     center: [$lon, $lat],
                     zoom: $zoom,
+                    preserveDrawingBuffer: true,
                     transformRequest: function( url, resourceType ) {
                       if (resourceType == 'Tile' && url.startsWith('https://vector.geobigdata')) {
                         return {
@@ -372,6 +375,26 @@ class Vectors(object):
                         "paint": style
                     });
                 });
+
+                map.on('load', function(e){
+                    setTimeout( function() {
+                        var mapCanvas = map.getCanvas();
+                        var thumbCanvas=document.createElement('canvas');
+                        var thumbContext=thumbCanvas.getContext('2d');
+                        var height = mapCanvas.scrollHeight;
+                        var width = mapCanvas.scrollWidth;
+                        thumbCanvas.width=width/2.0;
+                        thumbCanvas.height=height/2.0;
+                        thumbContext.drawImage(mapCanvas, 0, 0, width*2, height*2, 0, 0, width/2, height/2)
+                        var dataURL = thumbCanvas.toDataURL();
+                        var imageData = dataURL.substring(dataURL.indexOf(',')+1)
+                        var cell = Jupyter.notebook.get_selected_cell();
+                        cell.metadata.GBDX = cell.metadata.GBDX || {};
+                        cell.metadata.GBDX.static_thumbnail = cell.metadata.GBDX.static_thumbnail || {};
+                        cell.metadata.GBDX.static_thumbnail.data = cell.metadata.GBDX.static_thumbnail.data || {};
+                        cell.metadata.GBDX.static_thumbnail.data["image/png"] = imageData;
+                    }, 5000);
+                })
             });
         """).substitute({
             "map_id": map_id,
@@ -414,16 +437,18 @@ class Vectors(object):
         map_id = "map_{}".format(str(int(time.time())))
         display(HTML(Template('''
            <div id="$map_id"/>
-           <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.37.0/mapbox-gl.css' rel='stylesheet' />
+           <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
            <style>body{margin:0;padding:0;}#$map_id{position:relative;top:0;bottom:0;width:100%;height:400px;}</style>
-           <style>.mapboxgl-popup-content table tr{border: 1px solid #efefef;} .mapboxgl-popup-content table, td, tr{border: none;}</style>
+           <style>.mapboxgl-popup-content table tr{border: 1px solid #efefef;} .mapboxgl-popup-content table, td, tr{border: none;}
+           .mapboxgl-popup-content table {width: 100%; table-layout: fixed; text-align: left;} .mapboxgl-popup-content td:first-of-type{width: 33%;}
+           .mapboxgl-popup-content {width: 400px !important;} .mapboxgl-popup-content td:last-of-type{overflow-x: scroll;}<style>
         ''').substitute({"map_id": map_id})))
 
     
         js = Template("""
             require.config({
               paths: {
-                  mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.37.0/mapbox-gl',
+                  mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl',
               }
             });
     
@@ -446,7 +471,8 @@ class Vectors(object):
                     container: '$map_id',
                     style: 'mapbox://styles/mapbox/satellite-v9',
                     center: [$lon, $lat],
-                    zoom: $zoom
+                    zoom: $zoom,
+                    preserveDrawingBuffer: true
                 });
                 var map = window.map;
                 var geojson = $geojson;
@@ -489,6 +515,26 @@ class Vectors(object):
                     }
                     addLayer(map);
                 });
+
+                map.on('load', function(e){
+                    setTimeout( function() {
+                        var mapCanvas = map.getCanvas();
+                        var thumbCanvas=document.createElement('canvas');
+                        var thumbContext=thumbCanvas.getContext('2d');
+                        var height = mapCanvas.scrollHeight;
+                        var width = mapCanvas.scrollWidth;
+                        thumbCanvas.width=width/2.0;
+                        thumbCanvas.height=height/2.0;
+                        thumbContext.drawImage(mapCanvas, 0, 0, width*2, height*2, 0, 0, width/2, height/2)
+                        var dataURL = thumbCanvas.toDataURL();
+                        var imageData = dataURL.substring(dataURL.indexOf(',')+1)
+                        var cell = Jupyter.notebook.get_selected_cell();
+                        cell.metadata.GBDX = cell.metadata.GBDX || {};
+                        cell.metadata.GBDX.static_thumbnail = cell.metadata.GBDX.static_thumbnail || {};
+                        cell.metadata.GBDX.static_thumbnail.data = cell.metadata.GBDX.static_thumbnail.data || {};
+                        cell.metadata.GBDX.static_thumbnail.data["image/png"] = imageData;
+                    }, 5000);
+                })
             });
         """).substitute({
             "map_id": map_id, 


### PR DESCRIPTION
`map` and `tilemap` still need a refactor but this gets in the automatic generation of embedded thumbnails for the slippy maps, and fixes the feature popup tables so they display at a sensible size.