### PR TITLE
Fix plotting 3-band false color images

### DIFF
--- a/gbdxtools/images/meta.py
+++ b/gbdxtools/images/meta.py
@@ -156,7 +156,13 @@ class PlotMixin(object):
         return out
 
     def rgb(self, **kwargs):
-        data = self._read(self[kwargs.get("bands", self._rgb_bands),...], **kwargs)
+        if "bands" in kwargs:
+            use_bands = kwargs["bands"]
+            assert len(use_bands) == 3, 'Plot method only supports single or 3-band outputs'
+            del kwargs["bands"]
+        else:
+            use_bands = self.rgb_bands
+        data = self._read(self[use_bands,...], **kwargs)
         data = np.rollaxis(data.astype(np.float32), 0, 3)
         lims = np.percentile(data, kwargs.get("stretch", [2, 98]), axis=(0, 1))
         for x in xrange(len(data[0,0,:])):


### PR DESCRIPTION
Fixes the index error when specifying an arbitrary 3 bands to use for a false-color plot. Also adds a check and warning when trying to plot an image when the number of specified bands is not one or three.