### PR TITLE
skip tests if run in Travis

### DIFF
--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import numpy as np
 from gbdxtools.images.mixins.geo import PlotMixin
@@ -19,6 +20,9 @@ class PlotMock(np.ndarray, PlotMixin):
 
 class PlotTest(unittest.TestCase):
 
+    def setUp(self):
+        if 'TRAVIS' in os.environ:
+            self.skipTest("Travis can't test plots - no display")
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
If the test is run in Travis there's no display to plot to. So we'll skip the tests for now.