### PR TITLE
Pass through RDA errors

### DIFF
--- a/gbdxtools/ipe/graph.py
+++ b/gbdxtools/ipe/graph.py
@@ -42,6 +42,9 @@ def register_ipe_graph(conn, ipe_graph):
 def get_ipe_metadata(conn, ipe_id, node='toa_reflectance'):
     md_response = conn.get(VIRTUAL_IPE_URL + "/metadata/{}/{}/metadata.json".format(ipe_id, node)).result()
     if md_response.status_code != 200:
+        md_json = md_response.json()
+        if 'error' in md_json:
+            raise BadRequest("RDA error: {}".format(md_json['error']))
         raise BadRequest("Problem fetching image metadata: status {} {}, graph_id: {}".format(md_response.status_code, md_response.reason, ipe_id))
     else:
         md_json = md_response.json()

--- a/gbdxtools/ipe/util.py
+++ b/gbdxtools/ipe/util.py
@@ -57,7 +57,9 @@ def preview(image, **kwargs):
         return
 
     zoom = kwargs.get("zoom", 16)
-    bands = kwargs.get("bands", image._rgb_bands)
+    bands = kwargs.get("bands")
+    if bands is None:
+        bands = image._rgb_bands
     wgs84_bounds = kwargs.get("bounds", list(loads(image.ipe_metadata["image"]["imageBoundsWGS84"]).bounds))
     center = kwargs.get("center", list(shape(image).centroid.bounds[0:2]))
     graph_id = image.ipe_id

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import numpy as np
 from gbdxtools.images.mixins.geo import PlotMixin
@@ -19,6 +20,9 @@ class PlotMock(np.ndarray, PlotMixin):
 
 class PlotTest(unittest.TestCase):
 
+    def setUp(self):
+        if 'TRAVIS' in os.environ:
+            self.skipTest("Travis can't test plots - no display")
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
report the actual RDA error instead of just saying "400 metadata error"