### PR TITLE
support for blm on browse imagery via the new BrowseImage class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 0.15.6 
 * Fixed a band selection issue in image previews
 * changed the way we talked to the Openlayers objects in preview
+* Added a BrowseImage class for fetching and indexing browse imagery by catalogIDs
+* rgb and plot methods support base layer matching via browse imagery via the `blm_source="browse"` flag 
 
 0.15.5 
 * fix for missing import in geo mixin

--- a/gbdxtools/images/browse_image.py
+++ b/gbdxtools/images/browse_image.py
@@ -1,0 +1,73 @@
+import requests
+import numpy as np
+from skimage import io
+from shapely.geometry import shape
+
+class BrowseImage(object):
+    """
+      Image class for fetching and spatially indexing an image's browse image (low res previews)
+
+      Args:
+          catalog_id (str): the catalog id for the browse image
+          bbox (list): the bounding box in WGS84 coords for spatial indexing
+      Returns:
+          BrowseImage (object)
+    """    
+    def __init__(self, catalog_id, bbox=None):
+        
+        self.catalog_id = catalog_id
+        self._get_image()
+        self.metadata = self._get_metadata()
+        self.shape = self.image.shape
+        self.geom = self._get_geometry()
+        self.xmin, self.ymin, self.xmax, self.ymax = self.geom.bounds
+        self.cell_width = (self.xmax - self.xmin)/self.shape[1]
+        self.cell_height = (self.ymax - self.ymin)/self.shape[0]
+        self.bbox = bbox
+
+        if self.bbox is not None:
+            # find which cells intersect the bbox
+            bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax = self.bbox
+            window_xmin = int(np.floor((bbox_xmin - self.xmin)/self.cell_width))
+            window_xmax = int(np.ceil((bbox_xmax - self.xmin)/self.cell_width))
+            window_ymax = self.shape[0]-int(np.floor((bbox_ymin - self.ymin)/self.cell_height))
+            window_ymin = self.shape[0]-int(np.ceil((bbox_ymax - self.ymin)/self.cell_height))
+            self.window = ((window_ymin, window_ymax), (window_xmin, window_xmax))
+        else:
+            self.window = None
+
+            
+    def _get_image(self):
+        url = 'https://api.discover.digitalglobe.com/show?id={}'.format(self.catalog_id)
+        self.image = io.imread(url)
+            
+    def rgb(self):
+        return self.read()
+    
+    def _get_metadata(self):
+        url = 'https://geobigdata.io/thumbnails/v1/metadata/{}.json'.format(self.catalog_id)
+        response = requests.get(url)
+        return response.json()
+        
+    def _get_geometry(self):
+        if 'bbox' in self.metadata.keys():
+            geom = shape(self.metadata['bbox'])
+        elif 'geometry' in self.metadata.keys():
+            geom = shape(self.metadata['geometry'])
+        else:
+            raise ValueError("Invalid metadata returned by metadata service. Cannot create BrowseImage")
+        return geom
+        
+    def read(self):
+        if self.window is None:
+            return self.image
+        else:
+            (miny, maxy), (minx, maxx) = self.window
+            return self.image[miny:maxy,minx:maxx,:]
+        
+    def plot(self, w=10, h=10, title='', fontsize=24):
+        plt.figure(figsize=(w, h))
+        sp = plt.subplot(1, 1, 1)
+        plt.axis('off')
+        sp.set_title(title, fontsize=fontsize)
+        plt.imshow(self.rgb())


### PR DESCRIPTION
Addresses #355 via a new BrowseImage class and a flag for using it in plotting `blm_source="browse"` when `blm=True`

```python
from gbdxtools.task import env
from gbdxtools import CatalogImage
%matplotlib inline
catalog_id = env.inputs.get('catalog_id', '104001003589D300')
bbox = [131.018, -25.37, 131.074, -25.33]

image = CatalogImage(catalog_id, band_type="MS", bbox=bbox, acomp=True)
image = image.randwindow((500,500))
image.plot(blm=True, blm_source='browse')
```