### PR TITLE
switch to cdjs openlayers to get module exports

### DIFF
--- a/gbdxtools/ipe/util.py
+++ b/gbdxtools/ipe/util.py
@@ -89,7 +89,7 @@ def preview(image, **kwargs):
     js = Template("""
         require.config({
             paths: {
-                ol: 'https://openlayers.org/en/v4.6.4/build/ol',
+                ol: 'https://cdnjs.cloudflare.com/ajax/libs/openlayers/4.6.4/ol',
                 proj4: 'https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4'
             }
         });


### PR DESCRIPTION
OpenLayers was being sourced from openlayers.org. Versions from there do not have an AMD loader included, so require.js could not find the module to load. This presumably created a race condition where the global `ol` object might not be loaded fast enough.

This fix switches to the CDNJS hosted version which is built with an AMD loader. It is also minified and hosted in a CDN so loading should be faster.