### PR TITLE
indexing works correctly, but check upstream if returned value is Geo…

### DIFF
--- a/gbdxtools/images/rda_image.py
+++ b/gbdxtools/images/rda_image.py
@@ -128,7 +128,8 @@ class RDAImage(GeoDaskImage):
 
     def __getitem__(self, geometry):
         im = super(RDAImage, self).__getitem__(geometry)
-        im._rda_op = self._rda_op
+        if isinstance(im, GeoDaskImage):
+            im._rda_op = self._rda_op
         return im
 
     @property


### PR DESCRIPTION
…DaskImage or not (by definition a pixel or vector is not a GeoDaskImage just a dask array)