### PR TITLE
Histogram Improvements

### DIFF
--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -87,8 +87,14 @@ class PlotMixin(object):
             lims = np.percentile(band, kwargs.get("stretch", [2, 98]))
             top = lims[1]
             bottom = lims[0]
-            data[:,:,x] = (data[:,:,x] - bottom) / float(top - bottom)
-        return np.clip(data, 0, 1)
+            data[:,:,x] = (data[:,:,x] - bottom) / float(top - bottom) * 255.0
+        clipped = np.clip(data, 0, 255).astype("uint8")
+        if "gamma" in kwargs:
+            invGamma = 1.0 / kwargs['gamma']
+            lut = np.array([((i / 255.0) ** invGamma) * 255
+		            for i in np.arange(0, 256)]).astype("uint8")
+            clipped = np.take(lut, clipped)
+        return clipped
 
     def ndvi(self, **kwargs):
         data = self._read(self[self._ndvi_bands,...]).astype(np.float32)

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -21,7 +21,7 @@ class PlotMock(np.ndarray, PlotMixin):
 class PlotTest(unittest.TestCase):
 
     def setUp(self):
-        if 'TRAVIS' in os.environ:
+        if any(x in os.environ for x in ['TRAVIS', 'APPVEYOR']):
             self.skipTest("Travis can't test plots - no display")
 
     @classmethod


### PR DESCRIPTION
Updates and extends some of the image adjustment algorithms.

All algorithms will also ignore zero values added by padding when computing the image adjustment.

Calling just `rgb()` will use contrast stretch of 2% and 98%.

Optional arguments:

`stretch=[x, y]`will contrast stretch between x and y
`histogram='minmax'` will contrast stretch between 0% and 100%
`histogram='equalize'` will perform histogram equalization
`histogram='match'` will match the image histogram to the DG image base
`histogram='match', blm_source='browse'` will match the image histogram to the browse imagery
`gamma=X` will set image gamma
