### PR TITLE
change rev() to return tuple, convert to ndarry in transpix()

### DIFF
--- a/gbdxtools/images/meta.py
+++ b/gbdxtools/images/meta.py
@@ -348,7 +348,8 @@ class GeoDaskImage(DaskImage, Container, PlotMixin, BandMethodsTemplate, Depreca
         if isinstance(dem, np.ndarray):
             dem = tf.resize(np.squeeze(dem), xv.shape, preserve_range=True, order=1, mode="edge")
 
-        return self.__geo_transform__.rev(xv, yv, z=dem, _type=np.float32)[::-1]
+        coords = self.__geo_transform__.rev(xv, yv, z=dem)[::-1]
+        return np.asarray(coords, dtype=np.int32) 
 
     def _parse_geoms(self, **kwargs):
         """ Finds supported geometry types, parses them and returns the bbox """

--- a/gbdxtools/rda/util.py
+++ b/gbdxtools/rda/util.py
@@ -384,10 +384,12 @@ class AffineTransform(GeometricTransform):
         self._iaffine = None
         self.proj = proj
 
-    def rev(self, lng, lat, z=0, _type=np.int32):
+    def rev(self, lng, lat, z=0):
         if self._iaffine is None:
             self._iaffine = ~self._affine
-        return np.rint(np.asarray(self._iaffine * (lng, lat))).astype(_type)
+        #return np.rint(np.asarray(self._iaffine * (lng, lat))).astype(_type)
+        px, py = (self._iaffine * (lng, lat))
+        return int(round(px)), int(round(py)) 
 
     def fwd(self, x, y, z=0):
         return self._affine * (x, y)


### PR DESCRIPTION
Change the `__geo_transform__.rev()` method to return a tuple so that it works correctly with `shapely.ops.transform` (see #387). Previously it returned an `ndarray` for use in the `warp` method - now the conversion to `ndarray` is done as needed in the method instead.