### PR TITLE
Fix plot tests

### DIFF
--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -26,7 +26,7 @@ class PlotTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.zero = np.zeros((8,8,8))
+        cls.zero = np.random.rand(8,8,8) * 100.0
         cls.plotmock = cls.zero.view(PlotMock) 
 
     def test_plot_rgb(self):


### PR DESCRIPTION
Change the fake plot data to be random values instead of zeroes. This gives the contrast stretching values to compute a stretch over. When the values were all zero the contrast stretch would error causing the plot test to fail.