### PR TITLE
Export RGB adjusted geotiffs

### DIFF
--- a/gbdxtools/rda/io.py
+++ b/gbdxtools/rda/io.py
@@ -53,7 +53,6 @@ def to_geotiff(arr, path='./output.tif', proj=None, spec=None, bands=None, **kwa
                 offset = offsets[bands[x]] 
                 scale = scales[bands[x]] 
                 block[x,:,:] = block[x,:,:] * scale + offset 
-            # clipping may not be needed if the RDA transform is 100% safe
             return np.clip(block, 0, 255)
                 
         arr = arr[arr._rgb_bands,...]


### PR DESCRIPTION
This adds a `spec='rgb'` option to `image.geotiff()`. 

This will export the image as a RGB image with basic range adjustment applied. The dynamic range adjustment uses the values from the parent image strip as provided by RDA statistics. This allows Dask to build the geotiff without having to download any of the image first to compute statistics. Each chunk in Dask can then be computed individually.