### PR TITLE
Missing deprecation, legacy/backport support for ipe module

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -22,31 +22,54 @@ CatalogImage
     :param geojson (dict): a geojson geometry
     :returns image: an image class clipped to the given AOI
 
-.. function:: geotiff([path='output.tif', dtype=None, bands=None, proj=None, transform=None])
+.. function:: geotiff([path='output.tif', dtype=None, bands=None, proj=None, transform=None, spec=None])
 
-    Creates a geotiff from the image data
+    Creates a geotiff from the image data. To get an 8 bit color balanced image, pass spec='rgb'
 
     :param path (str): a path to write the geotiff to
     :param dtype (str): a datatype to use for the geotiff ('float32', 'uint16', 'uint8', 'etc')
     :param bands (list): a list of bands to save to the geotiff
     :param proj (str): an EPSG proj string 
-    :param transform (dict): an affine transformation to use for the new geotiff 
+    :param transform (dict): an affine transformation to use for the new geotiff
+    :param spec (str): spec to use for export - 'rgb' will export rgb bands as uint8 
 
     :returns path (str): the path to the created geotiff file on disk
 
-.. py:function:: plot([w=10, h=10, bands=None, cmap="Greys_r"])
+.. py:function:: plot([w=10, h=10, bands=None, cmap="Greys_r"], histogram=None, stretch=[2,98], gamma=1.0, blm_source=None)
 
     Plot the image via matplotlib. Defaults to plotting an RGB image unless the image only has one band.
+    Plot width and height refer to the total area of the plot, including margins. Dimensions are 
+    specified in inches. The plot will be generated at 72 pixels per inch. In Jupyter extra whitespace
+    will be removed so the final plot size will be smaller than the expected dimensions.
 
-    :param w: plot width
+    :param w: plot width 
     :param h: plot height
-    :param bands: A list of bands to plot
-    :param cmap: the matplotlib colormap to use in single band plots
+    :param bands (list): A list of bands to plot
+    :param cmap (str or cmap): the matplotlib colormap to use in single band plots
+    :param histogram (str): see rgb()
+    :param stretch (list of numbers): see rgb()
+    :param gamma (number): see rgb()
 
-.. py:function:: rgb()
+.. py:function:: rgb(histogram=None, stretch=[2,98], gamma=1.0, blm_source=None)
 
     Returns a uint8 Numpy array of the RGB bands for an image suitable for plotting with libraries like Matplotlib
-    
+
+    Several adjustment methods are available to tune the image appearance.
+
+    Without any parameters, rgb() and plot() will use a contrast stretch over the 2nd and 98th percentil pixel values on each band.
+
+    The parameter histogram='match' will contrast stretch over the minimum and maximum pixel values.
+    The parameter histogram='equalize' will perform histogram equalization on the image.
+    The parameter histogram='match' will match the image histogram to the same image bounds in the TMS base. Adding the parameter blm_source='browse' will use the Browse imagery instead.
+    The parameter 'stretch'=[low, high] will contrast stretch between the low and high values. histogram='minmax' is equivalent to stretch=[0,100].
+    The parameter 'gamma'=x will adjust the image gamma. Values of x greater than one will make the midtones brighter, values less than one make the midtones darker.
+    If the stretch and gamma parameters are included with a histogram parameter, the stretch and gamma will be applied after the histogram adjustments.
+
+    :param histogram (str): either 'minmax', 'equalize', or 'match'
+    :param stretch (list of numbers): a list of low and high cutoffs for contrast stretching
+    :param gamma (number): a value for the gamma adjustment
+    :param blm_source (str): if set to 'browse' use the Browse service for histogram matching
+
     :returns array (ndarray): A Numpy array of the RGB data 
 
 .. py:function:: ndvi()

--- a/gbdxtools/idaho.py
+++ b/gbdxtools/idaho.py
@@ -293,7 +293,7 @@ class Idaho(object):
 
         return urls, bboxes
 
-    def create_leaflet_viewer(self, idaho_image_results, filename):
+    def create_leaflet_viewer(self, idaho_image_results, filename, api_key=os.environ.get('MAPBOX_API_KEY', None)):
         """Create a leaflet viewer html file for viewing idaho images.
 
         Args:
@@ -301,6 +301,8 @@ class Idaho(object):
                                         the catalog.
             filename (str): Where to save output html file.
         """
+        
+        assert api_key is not None, "No Mapbox API Key found. You can either pass in a token or set the MAPBOX_API_KEY environment variable."
 
         description = self.describe_images(idaho_image_results)
         if len(description) > 0:
@@ -352,6 +354,7 @@ class Idaho(object):
             data = data.replace('CENTERLON', str(W))
             data = data.replace('BANDS', bandstr)
             data = data.replace('TOKEN', self.gbdx_connection.access_token)
+            data = data.replace('API_KEY', api_key)
 
             with codecs.open(filename, 'w', 'utf8') as outputfile:
                 self.logger.debug("Saving %s" % filename)

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -64,8 +64,8 @@ class PlotMixin(object):
             return image_equalized
 
     def blm_match(self, **kwargs):
-        deprecation('.blm_match() has been deprecated. Please use .histogram_match() instead.')
-        return self.rgb(**kwargs)
+        deprecation('.blm_match() has been deprecated. Please use .rgb(histogram="match")) instead.')
+        return self.rgb(histogram='match', **kwargs)
 
     def histogram_match(self, use_bands, blm_source=None, **kwargs):
         ''' Match the histogram to existing imagery '''

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -1,5 +1,6 @@
 import os
 import math
+from gbdxtools.rda.util import deprecation
 try:
     from rio_hist.match import histogram_match as rio_match
     has_rio = True
@@ -27,6 +28,7 @@ class PlotMixin(object):
         else:
             use_bands = self._rgb_bands
         if kwargs.get('blm') == True:
+            deprecation("blm=True has been deprecated. Please use histogram='match' instead.")
             return self.histogram_match(use_bands, **kwargs)
         if "histogram" not in kwargs:
             if "stretch" not in kwargs:
@@ -60,6 +62,10 @@ class PlotMixin(object):
             return self._histogram_stretch(image_equalized, **kwargs)
         else:
             return image_equalized
+
+    def blm_match(self, **kwargs):
+        deprecation('.blm_match() has been deprecated. Please use .histogram_match() instead.')
+        return self.rgb(**kwargs)
 
     def histogram_match(self, use_bands, blm_source=None, **kwargs):
         ''' Match the histogram to existing imagery '''

--- a/gbdxtools/images/rda_image.py
+++ b/gbdxtools/images/rda_image.py
@@ -1,7 +1,7 @@
 import math
 
 from gbdxtools.images.meta import DaskMeta, GeoDaskImage
-from gbdxtools.rda.util import RatPolyTransform, AffineTransform
+from gbdxtools.rda.util import RatPolyTransform, AffineTransform, deprecation
 from gbdxtools.rda.interface import DaskProps
 from gbdxtools.rda.graph import get_rda_graph
 from gbdxtools.auth import Auth
@@ -138,6 +138,11 @@ class RDAImage(GeoDaskImage):
 
     @property
     def rda(self):
+        return self._rda_op
+
+    @property
+    def ipe(self):
+        deprecation('The use of ipe/IPE has been deprecated. Please use rda/RDA.')
         return self._rda_op
 
     @property

--- a/gbdxtools/images/tms_image.py
+++ b/gbdxtools/images/tms_image.py
@@ -151,7 +151,7 @@ class TmsMeta(object):
         minx, miny, maxx, maxy = self._tile_coords(bounds)
         urls = {(y - miny, x - minx): self._url_template.format(z=self.zoom_level, x=x, y=y, token=self._token)
                 for y in xrange(miny, maxy + 1) for x in xrange(minx, maxx + 1)}
-        return urls, (3, self._tile_size * (maxy - miny), self._tile_size * (maxx - minx))
+        return urls, (3, self._tile_size * (maxy - miny + 1), self._tile_size * (maxx - minx + 1))
 
     def _expand_bounds(self, bounds):
         if bounds is None:

--- a/gbdxtools/leafletmap_template.html
+++ b/gbdxtools/leafletmap_template.html
@@ -27,7 +27,7 @@
 
 		var mymap = L.map('mapid');
 
-		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw', {
+		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=API_KEY', {
 			maxZoom: 18,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +


### PR DESCRIPTION
after deprecation the `ipe` module for `rda` (essentially only semantic changes), we provided no backport/legacy support for the deprecated module, which means any `.ipe` references will fail. 