### PR TITLE
legacy/backport support for ipe module

### DIFF
--- a/gbdxtools/deprecate.py
+++ b/gbdxtools/deprecate.py
@@ -1,0 +1,17 @@
+import sys, warnings
+
+def WrapMod(mod, deprecated):
+    """Return a wrapped object that warns about deprecated accesses"""
+    deprecated = set(deprecated)
+    class Wrapper(object):
+        def __getattr__(self, attr):
+            if attr in deprecated:
+                warnings.warn("Property %s is deprecated" % attr)
+
+            return getattr(mod, attr)
+
+        def __setattr__(self, attr, value):
+            if attr in deprecated:
+                warnings.warn("Property %s is deprecated" % attr)
+            return setattr(mod, attr, value)
+    return Wrapper()

--- a/gbdxtools/images/rda_image.py
+++ b/gbdxtools/images/rda_image.py
@@ -1,7 +1,7 @@
 import math
 
 from gbdxtools.images.meta import DaskMeta, GeoDaskImage
-from gbdxtools.rda.util import RatPolyTransform, AffineTransform
+from gbdxtools.rda.util import RatPolyTransform, AffineTransform, deprecation
 from gbdxtools.rda.interface import DaskProps
 from gbdxtools.rda.graph import get_rda_graph
 from gbdxtools.auth import Auth
@@ -138,6 +138,11 @@ class RDAImage(GeoDaskImage):
 
     @property
     def rda(self):
+        return self._rda_op
+
+    @property
+    def ipe(self):
+        deprecation('The use of ipe/IPE has been deprecated. Please use rda/RDA.')
         return self._rda_op
 
     @property

--- a/gbdxtools/ipe/__init__.py
+++ b/gbdxtools/ipe/__init__.py
@@ -1,0 +1,1 @@
+import sys

--- a/gbdxtools/ipe/__init__.py
+++ b/gbdxtools/ipe/__init__.py
@@ -1,1 +1,7 @@
 import sys
+import gbdxtools.rda
+from gbdxtools.rda.util import deprecation
+
+deprecation("The module 'gbdxtools.ipe' has been deprecated, functionality has been moved to gbdxtools.rda")
+
+sys.modules[__name__] = sys.modules['gbdxtools.rda']

--- a/gbdxtools/ipe/interface.py
+++ b/gbdxtools/ipe/interface.py
@@ -1,5 +1,0 @@
-from gbdxtools.rda.interface import RDA
-from gbdxtools.rda.util import deprecation
-
-deprecation('The use of ipe/IPE has been depricated. Please use rda/RDA')
-Ipe = RDA

--- a/gbdxtools/rda/interface.py
+++ b/gbdxtools/rda/interface.py
@@ -1,5 +1,5 @@
-import os
 import sys
+import os
 import uuid
 import json
 from hashlib import sha256
@@ -119,8 +119,8 @@ class Op(DaskProps):
 
         self._rda_id = None    # The graph ID
         self._rda_graph = None # the RDA graph
-        self._rda_meta = None  # Image metadata 
-        self._rda_stats = None # Display Stats  
+        self._rda_meta = None  # Image metadata
+        self._rda_stats = None # Display Stats
 
         self._interface = interface
 
@@ -181,3 +181,10 @@ class Op(DaskProps):
 class RDA(object):
     def __getattr__(self, name):
         return Op(name=name, interface=Auth())
+
+# Warn on deprecated module attribute access
+from gbdxtools.deprecate import WrapMod
+sys.modules[__name__] = WrapMod(sys.modules[__name__], deprecated=["Ipe"])
+Ipe = RDA
+
+


### PR DESCRIPTION
after deprecation the ipe module for rda (essentially only semantic changes), we provided no backport/legacy support for the deprecated module, which means any .ipe references will fail.