### PR TITLE
Dra previews

### DIFF
--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -50,7 +50,6 @@ class PlotMixin(object):
             return self.histogram_stretch(use_bands, stretch=[0, 100], **kwargs)
         # DRA'ed images should be left alone if not explicitly adjusted
         elif kwargs["histogram"] == "ignore" or self.options.get('dra'):
-            print('DRA')
             data = self._read(self[use_bands,...], **kwargs)
             return np.rollaxis(data, 0, 3)
         else:

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -36,9 +36,11 @@ class PlotMixin(object):
             use_bands = self._rgb_bands
         if kwargs.get('blm') == True:
             return self.histogram_match(use_bands, **kwargs)
+        # if not specified or DRA'ed, default to a 2-98 stretch
         if "histogram" not in kwargs:
             if "stretch" not in kwargs:
-                kwargs['stretch'] = [2,98]
+                if not self.options['dra']:
+                    kwargs['stretch'] = [2,98]
             return self.histogram_stretch(use_bands, **kwargs)
         elif kwargs["histogram"] == "equalize":
             return self.histogram_equalize(use_bands, **kwargs)
@@ -46,7 +48,9 @@ class PlotMixin(object):
             return self.histogram_match(use_bands, **kwargs)
         elif kwargs["histogram"] == "minmax":
             return self.histogram_stretch(use_bands, stretch=[0, 100], **kwargs)
-        elif kwargs["histogram"] == "ignore":
+        # DRA'ed images should be left alone if not explicitly adjusted
+        elif kwargs["histogram"] == "ignore" or self.options['dra']:
+            print('DRA')
             data = self._read(self[use_bands,...], **kwargs)
             return np.rollaxis(data, 0, 3)
         else:

--- a/gbdxtools/images/mixins/geo.py
+++ b/gbdxtools/images/mixins/geo.py
@@ -39,7 +39,7 @@ class PlotMixin(object):
         # if not specified or DRA'ed, default to a 2-98 stretch
         if "histogram" not in kwargs:
             if "stretch" not in kwargs:
-                if not self.options['dra']:
+                if not self.options.get('dra'):
                     kwargs['stretch'] = [2,98]
             return self.histogram_stretch(use_bands, **kwargs)
         elif kwargs["histogram"] == "equalize":
@@ -49,7 +49,7 @@ class PlotMixin(object):
         elif kwargs["histogram"] == "minmax":
             return self.histogram_stretch(use_bands, stretch=[0, 100], **kwargs)
         # DRA'ed images should be left alone if not explicitly adjusted
-        elif kwargs["histogram"] == "ignore" or self.options['dra']:
+        elif kwargs["histogram"] == "ignore" or self.options.get('dra'):
             print('DRA')
             data = self._read(self[use_bands,...], **kwargs)
             return np.rollaxis(data, 0, 3)

--- a/gbdxtools/rda/io.py
+++ b/gbdxtools/rda/io.py
@@ -54,18 +54,20 @@ def to_geotiff(arr, path='./output.tif', proj=None, spec=None, bands=None, **kwa
     dtype = arr.dtype.name if arr.dtype.name != 'int8' else 'uint8' 
 
     if spec is not None and spec.lower() == 'rgb':
-        # add the RDA HistogramDRA op to get a RGB 8-bit image
-        from gbdxtools.rda.interface import RDA
-        rda = RDA()
-        dra = rda.HistogramDRA(arr)
-        # Reset the bounds and select the bands on the new Dask
-        dra_aoi = dra.aoi(bbox=arr.bounds)
-        if bands is not None:
-            dra_aoi_bands = dra_aoi[bands,...]
-        else:
-            dra_aoi_bands = dra_aoi[arr._rgb_bands,...]
-        arr = dra_aoi_bands.astype(np.uint8)
-        dtype = 'uint8'
+        # skip if already DRA'ed
+        if not arr.options['dra']:
+            # add the RDA HistogramDRA op to get a RGB 8-bit image
+            from gbdxtools.rda.interface import RDA
+            rda = RDA()
+            dra = rda.HistogramDRA(arr)
+            # Reset the bounds and select the bands on the new Dask
+            dra_aoi = dra.aoi(bbox=arr.bounds)
+            if bands is not None:
+                dra_aoi_bands = dra_aoi[bands,...]
+            else:
+                dra_aoi_bands = dra_aoi[arr._rgb_bands,...]
+            arr = dra_aoi_bands.astype(np.uint8)
+            dtype = 'uint8'
     else:
         if bands is not None:
             arr = arr[bands,...]

--- a/gbdxtools/rda/io.py
+++ b/gbdxtools/rda/io.py
@@ -54,6 +54,8 @@ def to_geotiff(arr, path='./output.tif', proj=None, spec=None, bands=None, **kwa
     dtype = arr.dtype.name if arr.dtype.name != 'int8' else 'uint8' 
 
     if spec is not None and spec.lower() == 'rgb':
+        if bands is None:
+            bands = arr._rgb_bands
         # skip if already DRA'ed
         if not arr.options['dra']:
             # add the RDA HistogramDRA op to get a RGB 8-bit image
@@ -61,13 +63,9 @@ def to_geotiff(arr, path='./output.tif', proj=None, spec=None, bands=None, **kwa
             rda = RDA()
             dra = rda.HistogramDRA(arr)
             # Reset the bounds and select the bands on the new Dask
-            dra_aoi = dra.aoi(bbox=arr.bounds)
-            if bands is not None:
-                dra_aoi_bands = dra_aoi[bands,...]
-            else:
-                dra_aoi_bands = dra_aoi[arr._rgb_bands,...]
-            arr = dra_aoi_bands.astype(np.uint8)
-            dtype = 'uint8'
+            arr = dra.aoi(bbox=arr.bounds)
+        arr = arr[bands,...].astype(np.uint8)
+        dtype = 'uint8'
     else:
         if bands is not None:
             arr = arr[bands,...]

--- a/gbdxtools/rda/io.py
+++ b/gbdxtools/rda/io.py
@@ -57,7 +57,7 @@ def to_geotiff(arr, path='./output.tif', proj=None, spec=None, bands=None, **kwa
         if bands is None:
             bands = arr._rgb_bands
         # skip if already DRA'ed
-        if not arr.options['dra']:
+        if not arr.options.get('dra'):
             # add the RDA HistogramDRA op to get a RGB 8-bit image
             from gbdxtools.rda.interface import RDA
             rda = RDA()

--- a/gbdxtools/rda/util.py
+++ b/gbdxtools/rda/util.py
@@ -82,7 +82,7 @@ def preview(image, **kwargs):
         proj_info = {}
         bounds = wgs84_bounds
     # Applying DRA to a DRA'ed image looks bad, skip if already in graph
-    if 'RadiometricDRA' not in [node['operator'] for node in image.rda.graph()['nodes']]:
+    if not image.options['dra']:
         rda = RDA()
         # Need some simple DRA to get the image in range for display.
         dra = rda.HistogramDRA(image)

--- a/gbdxtools/rda/util.py
+++ b/gbdxtools/rda/util.py
@@ -82,7 +82,7 @@ def preview(image, **kwargs):
         proj_info = {}
         bounds = wgs84_bounds
     # Applying DRA to a DRA'ed image looks bad, skip if already in graph
-    if not image.options['dra']:
+    if not image.options.get('dra'):
         rda = RDA()
         # Need some simple DRA to get the image in range for display.
         dra = rda.HistogramDRA(image)

--- a/gbdxtools/rda/util.py
+++ b/gbdxtools/rda/util.py
@@ -81,10 +81,12 @@ def preview(image, **kwargs):
     else:
         proj_info = {}
         bounds = wgs84_bounds
-
-    rda = RDA()
-    dra = rda.HistogramDRA(image)
-    image = dra.aoi(bbox=image.bounds)
+    # Applying DRA to a DRA'ed image looks bad, skip if already in graph
+    if 'RadiometricDRA' not in [node['operator'] for node in image.rda.graph()['nodes']]:
+        rda = RDA()
+        # Need some simple DRA to get the image in range for display.
+        dra = rda.HistogramDRA(image)
+        image = dra.aoi(bbox=image.bounds)
     graph_id = image.rda_id
     node_id = image.rda.graph()['nodes'][0]['id']
     map_id = "map_{}".format(str(int(time.time())))


### PR DESCRIPTION
When image objects have the DRA enabled:

* don't use DRA on `preview()`
* don't use DRA on `geotiff(spec='rgb')`
* don't use DRA on `plot()` unless an additional `stretch` or `histogram` is specified