### PR TITLE
add handling for single band images in maps

### DIFF
--- a/gbdxtools/vectors.py
+++ b/gbdxtools/vectors.py
@@ -341,7 +341,7 @@ class Vectors(object):
 
     def map(self, features=None, query=None, styles=None,
                   bbox=[-180,-90,180,90], zoom=10, center=None, 
-                  image=None, image_bounds=None, cmap=None,
+                  image=None, image_bounds=None, cmap='viridis',
                   api_key=os.environ.get('MAPBOX_API_KEY', None), **kwargs):
         """
           Renders a mapbox gl map from a vector service query or a list of geojson features
@@ -356,7 +356,7 @@ class Vectors(object):
             api_key (str): a valid Mapbox API key
             image (dict): a CatalogImage or a ndarray
             image_bounds (list): a list of bounds for image positioning 
-            cmap (str): MatPlotLib colormap to use for rendering single band images
+            cmap (str): MatPlotLib colormap to use for rendering single band images (default: viridis)
         
         """
         try:
@@ -405,7 +405,7 @@ class Vectors(object):
         })
         template.inject()
 
-    def _build_image_layer(self, image, image_bounds, cmap):
+    def _build_image_layer(self, image, image_bounds, cmap='viridis'):
         if image is not None:
             if isinstance(image, da.Array):
                 if len(image.shape) == 2 or \

--- a/gbdxtools/vectors.py
+++ b/gbdxtools/vectors.py
@@ -341,7 +341,7 @@ class Vectors(object):
 
     def map(self, features=None, query=None, styles=None,
                   bbox=[-180,-90,180,90], zoom=10, center=None, 
-                  image=None, image_bounds=None,
+                  image=None, image_bounds=None, cmap=None,
                   api_key=os.environ.get('MAPBOX_API_KEY', None), **kwargs):
         """
           Renders a mapbox gl map from a vector service query or a list of geojson features
@@ -356,6 +356,7 @@ class Vectors(object):
             api_key (str): a valid Mapbox API key
             image (dict): a CatalogImage or a ndarray
             image_bounds (list): a list of bounds for image positioning 
+            cmap (str): MatPlotLib colormap to use for rendering single band images
         
         """
         try:
@@ -385,7 +386,7 @@ class Vectors(object):
 
         map_id = "map_{}".format(str(int(time.time())))
         map_data = VectorGeojsonLayer(geojson, styles=styles, **kwargs)
-        image_layer = self._build_image_layer(image, image_bounds)
+        image_layer = self._build_image_layer(image, image_bounds, cmap)
 
         template = BaseTemplate(map_id, **{
             "lat": lat, 
@@ -399,16 +400,19 @@ class Vectors(object):
         })
         template.inject()
 
-    def _build_image_layer(self, image, image_bounds):
+    def _build_image_layer(self, image, image_bounds, cmap):
         if image is not None:
             if isinstance(image, da.Array):
-                arr = image.rgb()
+                if len(image.shape) == 2:
+                    arr = image.compute()
+                else:
+                    arr = image.rgb()
                 coords = box(*image.bounds)
             else:
                 assert image_bounds is not None, "Must pass image_bounds with ndarray images"
                 arr = image
                 coords = box(*image_bounds)
-            b64 = self._encode_image(arr)
+            b64 = self._encode_image(arr, cmap)
             return ImageLayer(b64, self._polygon_coords(coords))
         else:
             return 'false';
@@ -417,9 +421,9 @@ class Vectors(object):
         c = list(map(list, list(g.exterior.coords)))
         return [c[2], c[1], c[0], c[3]]
 
-    def _encode_image(self, arr):
+    def _encode_image(self, arr, cmap):
         io = BytesIO()
-        imsave(io, arr)
+        imsave(io, arr, cmap=cmap)
         io.seek(0)
         img_str = base64.b64encode(io.getvalue()).decode()
         return 'data:image/{};base64,{}'.format('png', img_str)


### PR DESCRIPTION
Addresses #638 by adding support for single band images in slippy maps, and the ability to specify the colormap used for those images.