### PR TITLE
Issue 723 - multiplexed outputs

### DIFF
--- a/gbdxtools/simpleworkflows.py
+++ b/gbdxtools/simpleworkflows.py
@@ -464,16 +464,18 @@ class Workflow(object):
                                  input_port_name in t.inputs._portnames]
         for task in self.tasks:
             # only include multiplex output ports in this task if other tasks refer to them in their inputs.
+            # skip this if there is only one task in the workflow
             # 1. find the multplex output port_names in this task
             # 2. see if they are referred to in any other tasks inputs
             # 3. If not, exclude them from the workflow_def
             output_multiplex_ports_to_exclude = []
-            multiplex_output_port_names = [portname for portname in task.outputs._portnames if
-                                           task.outputs.__getattribute__(portname).is_multiplex]
-            for p in multiplex_output_port_names:
-                output_port_reference = 'source:' + task.name + ':' + p
-                if output_port_reference not in all_input_port_values:
-                    output_multiplex_ports_to_exclude.append(p)
+            if len(self.tasks) > 1:
+                multiplex_output_port_names = [portname for portname in task.outputs._portnames if
+                                            task.outputs.__getattribute__(portname).is_multiplex]
+                for p in multiplex_output_port_names:
+                    output_port_reference = 'source:' + task.name + ':' + p
+                    if output_port_reference not in all_input_port_values:
+                        output_multiplex_ports_to_exclude.append(p)
 
             task_def = task.generate_task_workflow_json(
                 output_multiplex_ports_to_exclude=output_multiplex_ports_to_exclude)


### PR DESCRIPTION
Multiplexed outputs are ignored if they don't have matching inputs. If there is only one task in a workflow, then there are no inputs to be matched to. This means a single multiplexed task's outputs cannot be accessed.

 Several users have tried to use the 'RDA_Materialization' task by itself. Since this task is multiplexed, the resulting image file is ignored as an output and can not save. There is also the `RDA_Materialization_Simple` task that is not multiplexed, but the distinction between the two tasks is not evident unless the user compares the task definitions.

This skips the output matching if there is only one task.

Ideally, unmatched multiplex outputs should only be ignored if there is one or more matching inputs on the next task. This would let any multiplex task that is at the "end of the line" have accessible outputs. However, this problem has not been reported by users yet.