### PR TITLE
Issue #762 NDVI bands borked

### DIFF
--- a/gbdxtools/images/worldview.py
+++ b/gbdxtools/images/worldview.py
@@ -156,5 +156,6 @@ class WV04(WorldViewImage):
     def _rgb_bands(self):
         return [2,1,0]
 
+    @property
     def _ndvi_bands(self):
-        return [1,3]
+        return [2,3]


### PR DESCRIPTION
`_ndvi_bands()` was missing the `@property` declarations and was using the wrong band for `red`.