### PR TITLE
GBDXA-414 removed DG Maps API, using generic mapbox map id

### DIFF
--- a/docs/imagery_access.rst
+++ b/docs/imagery_access.rst
@@ -223,7 +223,7 @@ Beyond replacing catalog ids for AOIs, the ``DemImage`` class shares all the sam
 TMS Images
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``TmsImage`` class is used to access imagery available from the `DigitalGlobe Maps API <https://platform.digitalglobe.com/maps-api/>`_. These are global mosiacs of imagery that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. Since the Maps API is static, or changes less frequently, these images are best suited when there are no temporal requirements on an analysis. The zoom level to use can be specified (default is 22). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
+The ``TmsImage`` class is used to access imagery available from the `Mapbox Raster Tiles API <https://docs.mapbox.com/api/maps/#retrieve-raster-tiles>`_. These are global mosiacs of imagery that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. Since Mapbox API is static, or changes less frequently, these images are best suited when there are no temporal requirements on an analysis. The zoom level to use can be specified (default is 22). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
 
 .. code-block:: python
 

--- a/gbdxtools/images/dem_image.py
+++ b/gbdxtools/images/dem_image.py
@@ -41,5 +41,5 @@ class DemImage(RDABaseImage):
         wkt = box(*aoi).wkt
         dem = rda.IdahoTemplate(bucketName=bucket, imageId=imageId, objectStore="S3", geospatialWKT=str(wkt), nodeId="GeospatialCrop")
         if proj is not "EPSG:4326":
-            dem = dem(**reproject_params(proj), nodeId="Reproject")
+            dem = dem(nodeId="Reproject", **reproject_params(proj))
         return dem

--- a/gbdxtools/images/tms_image.py
+++ b/gbdxtools/images/tms_image.py
@@ -78,7 +78,7 @@ def raise_aoi_required():
 
 class TmsMeta(object):
     def __init__(self, access_token=os.environ.get("MAPBOX_API_KEY"),
-                 url="https://api.mapbox.com/v4/digitalglobe.nal0g75k/{z}/{x}/{y}.png",
+                 url="https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png",
                  zoom=22, bounds=None):
         self.zoom_level = zoom
         self._token = access_token
@@ -215,7 +215,7 @@ class TmsImage(GeoDaskImage):
     _default_proj = "EPSG:3857"
 
     def __new__(cls, access_token=os.environ.get("MAPBOX_API_KEY"),
-                url="https://api.mapbox.com/v4/digitalglobe.nal0g75k/{z}/{x}/{y}.png",
+                url="https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png",
                 zoom=22, **kwargs):
         _tms_meta = TmsMeta(access_token=access_token, url=url, zoom=zoom, bounds=kwargs.get("bounds"))
         gi = mapping(box(*_tms_meta.bounds))


### PR DESCRIPTION
- DG Maps API is going away. I substituted that `map_id` with a generic mapbox `map_id`.
- Fixed argument ordering for python 2/3