### PR TITLE
ISS 777: Fix hardcoded TmsImage url

### DIFF
--- a/docs/imagery_access.rst
+++ b/docs/imagery_access.rst
@@ -223,13 +223,14 @@ Beyond replacing catalog ids for AOIs, the ``DemImage`` class shares all the sam
 TMS Images
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``TmsImage`` class is used to access imagery available from the `Mapbox Raster Tiles API <https://docs.mapbox.com/api/maps/#retrieve-raster-tiles>`_. These are global mosiacs of imagery that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. Since Mapbox API is static, or changes less frequently, these images are best suited when there are no temporal requirements on an analysis. The zoom level to use can be specified (default is 22). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
+The ``TmsImage`` class is used to access imagery available from a Tile Map Service (TMS). These can be used as a static imagery source that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. The zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image.
 
 .. code-block:: python
 
     from gbdxtools import TmsImage
 
-    img = TmsImage(zoom=13)
+    url = r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?flipy=true&connectId=<connectid>"
+    img = TmsImage(url, zoom=13)
     print(img.shape)
     aoi = img.aoi(bbox=[-109.84, 43.19, -109.59, 43.34])
     print(aoi.shape)

--- a/docs/imagery_access.rst
+++ b/docs/imagery_access.rst
@@ -223,20 +223,26 @@ Beyond replacing catalog ids for AOIs, the ``DemImage`` class shares all the sam
 TMS Images
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``TmsImage`` class is used to access imagery available from a Tile Map Service (TMS). These can be used as a static imagery source that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. The zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image.
+The ``TmsImage`` class is used to convert TMS-based imagery into NumPy arrays. The zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image.
 
-Subscribers to the new EarthWatch TMS service can use this image class to access EarthWatch base imagery in Python. Use the following configuration, substituting a valid ConnectID string.
+The following example shows plotting an image generated from OpenStreetMap tiles:
 
 .. code-block:: python
 
     from gbdxtools import TmsImage
 
-    url = r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?flipy=true&connectId=<connectid>"
+    url = r'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
     img = TmsImage(url, zoom=13)
     print(img.shape)
     aoi = img.aoi(bbox=[-109.84, 43.19, -109.59, 43.34])
     print(aoi.shape)
     aoi.plot()
+
+Subscribers to the EarthWatch TMS service can use this image class to access EarthWatch base imagery in Python. Use the following configuration, substituting a valid ConnectID string:
+
+.. code-block:: python
+
+    img = TmsImage(r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?flipy=true&connectId=<connectid>", zoom=13)
 
 
 S3 Images

--- a/docs/imagery_access.rst
+++ b/docs/imagery_access.rst
@@ -225,6 +225,8 @@ TMS Images
 
 The ``TmsImage`` class is used to access imagery available from a Tile Map Service (TMS). These can be used as a static imagery source that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. The zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image.
 
+Subscribers to the new EarthWatch TMS service can use this image class to access EarthWatch base imagery in Python. Use the following configuration, substituting a valid ConnectID string.
+
 .. code-block:: python
 
     from gbdxtools import TmsImage

--- a/gbdxtools/images/tms_image.py
+++ b/gbdxtools/images/tms_image.py
@@ -80,7 +80,7 @@ class TmsMeta(object):
     def __init__(self, url, zoom=18, bounds=None):
         self.zoom_level = zoom
         self._name = "image-{}".format(str(uuid.uuid4()))
-        self._url_template = url
+        self._url = url
 
         _first_tile = mercantile.Tile(z=self.zoom_level, x=0, y=0)
         _last_tile = mercantile.Tile(z=self.zoom_level, x=180, y=-85.05)
@@ -146,7 +146,7 @@ class TmsMeta(object):
 
     def _collect_urls(self, bounds):
         minx, miny, maxx, maxy = self._tile_coords(bounds)
-        urls = {(y - miny, x - minx): self._url_template.format(z=self.zoom_level, x=x, y=y)
+        urls = {(y - miny, x - minx): self._url.format(z=self.zoom_level, x=x, y=y)
                 for y in xrange(miny, maxy + 1) for x in xrange(minx, maxx + 1)}
         return urls, (3, self._tile_size * (maxy - miny + 1), self._tile_size * (maxx - minx + 1))
 
@@ -207,7 +207,7 @@ class TmsImage(GeoDaskImage):
         bbox (list): (optional) Bounding box of AOI, if aoi() method is not used.
 
     Example:
-        >>> img = TmsImage(url=r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?connectId=", zoom=13, bbox=[-109.84, 43.19, -109.59, 43.34])'''
+        >>> img = TmsImage(r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?connectId=", zoom=13, bbox=[-109.84, 43.19, -109.59, 43.34])'''
 
 
     _default_proj = "EPSG:3857"

--- a/gbdxtools/images/tms_image.py
+++ b/gbdxtools/images/tms_image.py
@@ -77,13 +77,10 @@ def raise_aoi_required():
 
 
 class TmsMeta(object):
-    def __init__(self, access_token=os.environ.get("MAPBOX_API_KEY"),
-                 url="https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png",
-                 zoom=22, bounds=None):
+    def __init__(self, url, zoom=18, bounds=None):
         self.zoom_level = zoom
-        self._token = access_token
         self._name = "image-{}".format(str(uuid.uuid4()))
-        self._url_template = url + "?access_token={token}"
+        self._url_template = url
 
         _first_tile = mercantile.Tile(z=self.zoom_level, x=0, y=0)
         _last_tile = mercantile.Tile(z=self.zoom_level, x=180, y=-85.05)
@@ -149,7 +146,7 @@ class TmsMeta(object):
 
     def _collect_urls(self, bounds):
         minx, miny, maxx, maxy = self._tile_coords(bounds)
-        urls = {(y - miny, x - minx): self._url_template.format(z=self.zoom_level, x=x, y=y, token=self._token)
+        urls = {(y - miny, x - minx): self._url_template.format(z=self.zoom_level, x=x, y=y)
                 for y in xrange(miny, maxy + 1) for x in xrange(minx, maxx + 1)}
         return urls, (3, self._tile_size * (maxy - miny + 1), self._tile_size * (maxx - minx + 1))
 
@@ -196,32 +193,31 @@ class TmsMeta(object):
 
 
 class TmsImage(GeoDaskImage):
-    ''' An image built from the DigitalGlobe Maps API TMS tiles
+    ''' An image built from a user given API TMS tiles
 
-    These are global mosiacs of imagery that can be an effective source for training Machine Learning algorithms or whenever high-resolution is needed. Since the Maps API is static, or changes less frequently, these images are best suited when there are no temporal requirements on an analysis. 
+    These images will be subject to the rules and metadata of the source TMS tiles
     
-    Instead of an ID the zoom level to use can be specified (default is 22). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
+    Instead of an ID the zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
 
     Supports the basic methods shared by Catalog Images such as plot() and geotiff().
 
     Args:
-        zoom (int): (optional) Zoom level to use as the source if the image, default is 22
+        url (str): (required) The url of the Tms service to be used in the request (ex: https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?connectId=connectid)
+        zoom (int): (optional) Zoom level to use as the source if the image, default is 18
         bbox (list): (optional) Bounding box of AOI, if aoi() method is not used.
 
     Example:
-        >>> img = TmsImage(zoom=13, bbox=[-109.84, 43.19, -109.59, 43.34])'''
+        >>> img = TmsImage(url=r"https://earthwatch.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{y}.jpg?connectId=", zoom=13, bbox=[-109.84, 43.19, -109.59, 43.34])'''
 
 
     _default_proj = "EPSG:3857"
 
-    def __new__(cls, access_token=os.environ.get("MAPBOX_API_KEY"),
-                url="https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png",
-                zoom=22, **kwargs):
-        _tms_meta = TmsMeta(access_token=access_token, url=url, zoom=zoom, bounds=kwargs.get("bounds"))
+    def __new__(cls, url, zoom=18, **kwargs):
+        _tms_meta = TmsMeta(url=url, zoom=zoom, bounds=kwargs.get("bounds"))
         gi = mapping(box(*_tms_meta.bounds))
         gt = _tms_meta.__geo_transform__
         self =  super(TmsImage, cls).__new__(cls, _tms_meta, __geo_transform__ = gt, __geo_interface__ = gi)
-        self._base_args = {"access_token": access_token, "url": url, "zoom": zoom}
+        self._base_args = {"url": url, "zoom": zoom}
         self._tms_meta = _tms_meta
         g = self._parse_geoms(**kwargs)
         if g is not None:

--- a/gbdxtools/images/tms_image.py
+++ b/gbdxtools/images/tms_image.py
@@ -197,7 +197,7 @@ class TmsImage(GeoDaskImage):
 
     These images will be subject to the rules and metadata of the source TMS tiles
     
-    Instead of an ID the zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image. Note that different image sources are used at different zoom levels.
+    Instead of an ID the zoom level to use can be specified (default is 18). Changing the zoom level will change the resolution of the image.
 
     Supports the basic methods shared by Catalog Images such as plot() and geotiff().
 

--- a/tests/unit/test_tms_image.py
+++ b/tests/unit/test_tms_image.py
@@ -46,7 +46,8 @@ class TmsImageTest(unittest.TestCase):
         print("Created: {}".format(cls._temp_path))
 
     def test_tms_image_global(self):
-        img = self.gbdx.tms_image(zoom=18)
+        url = r"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        img = TmsImage(url=url, zoom=18)
         self.assertTrue(isinstance(img, TmsImage))
         assert img.shape == (3, 67106304, 67108864)
         assert img.proj == 'EPSG:3857'
@@ -56,7 +57,8 @@ class TmsImageTest(unittest.TestCase):
         # a 1 x 4 chunk of tiles, so 256 x 1024 pixels
         # then offset by 1/2 tile in x and y
         bbox = [-74.71046447753906, 40.53624234037728, -74.70909118652344, 40.54041698756514]
-        img = self.gbdx.tms_image(zoom=18, bbox=bbox)
+        url = r"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        img = TmsImage(url=url, zoom=18, bbox=bbox)
         self.assertTrue(isinstance(img, TmsImage))
         assert img.shape == (3, 1024, 256)
         assert img.proj == 'EPSG:3857'
@@ -66,7 +68,8 @@ class TmsImageTest(unittest.TestCase):
         # a 1 x 4 chunk of tiles, so 256 x 1024 pixels
         # then offset by 1/2 tile in x and y
         bbox = [-74.71046447753906, 40.53624234037728, -74.70909118652344, 40.54041698756514]
-        img = self.gbdx.tms_image(zoom=18)
+        url = r"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        img = TmsImage(url=url, zoom=18)
         aoi = img.aoi(bbox=bbox)
         self.assertTrue(isinstance(aoi, TmsImage))
         assert aoi.shape == (3, 1024, 256)


### PR DESCRIPTION
I updated the functionality of the class.  It now requires you to pass a url to the class.  I have removed all reference to mapbox and access_tokens.  This should now work for any tms service passed to it.

```bbox = [-74.71046447753906, 40.53624234037728, -74.70909118652344, 40.54041698756514]
url = r"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
img = TmsImage(url=url, zoom=18)
img2 = TmsImage(url=url, zoom=18, bbox=bbox)
aoi = img.aoi(bbox=bbox)
print(img)
print(aoi)
print(img2)
aoi.plot(), img2.plot()